### PR TITLE
Fix obfuscating non-ASCII passwords

### DIFF
--- a/modules/cesecore-common/src/org/cesecore/util/StringTools.java
+++ b/modules/cesecore-common/src/org/cesecore/util/StringTools.java
@@ -622,23 +622,26 @@ public final class StringTools {
         final byte[] b = s.getBytes();
 
         for (int i = 0; i < b.length; i++) {
-            final byte b1 = b[i];
-            final byte b2 = b[s.length() - (i + 1)];
+            final int b1 = b[i] & 0xff;
+            // If both bytes are ASCII, they are just converted to an unsigned int. If b2 is higher than ASCII, it is
+            // wrapped around after 128. If b1 is higher than ASCII, 128 is added to b2. This makes sure that i2 stays
+            // between 0 - 256.
+            final int b2 = b[b.length - (i + 1)] & 0x7f | (b1 & 0x80);
             final int i1 = b1 + b2 + 127;
             final int i2 = b1 - b2 + 127;
             final int i0 = i1 * 256 + i2;
-            final String x = Integer.toString(i0, 36);
-
-            switch (x.length()) {
-            case 1:
-            case 2:
-            case 3:
-                buf.append('0');
-                break;
-            default:
-                buf.append(x);
-                break;
+            if (i0 < 0) {
+                throw new IllegalStateException("Negative number " + i0);
             }
+            final String x = Integer.toString(i0, 36);
+            if (x.length() > 4) {
+                throw new IllegalStateException("Too long integer " + x);
+            }
+            // Pad with leading zeros
+            for (int j = 0; j < 4 - x.length(); j++) {
+                buf.append('0');
+            }
+            buf.append(x);
         }
         return buf.toString();
 


### PR DESCRIPTION
Fixes a bug in handling of Unicode string length. Using characters outside the ASCII range in an end entity password caused the following error:

```txt
Caused by: java.lang.ArrayIndexOutOfBoundsException: Index -1 out of bounds for length 40
        at deployment.ejbca.ear//org.cesecore.util.StringTools.obfuscate(StringTools.java:626)
        at deployment.ejbca.ear//org.ejbca.core.ejb.ra.UserData.setOpenPassword(UserData.java:499)
        at deployment.ejbca.ear.ejbca-ejb.jar//org.ejbca.core.ejb.ra.EndEntityManagementSessionBean.setPassword(EndEntityManagementSessionBean.java:1510)
        at deployment.ejbca.ear.ejbca-ejb.jar//org.ejbca.core.ejb.ra.EndEntityManagementSessionBean.setClearTextPassword(EndEntityManagementSessionBean.java:1451)
```