### PR TITLE
MS Auto-Enrollment: Fix field format information in GUI

### DIFF
--- a/modules/admin-gui/resources/languages/languagefile.en.properties
+++ b/modules/admin-gui/resources/languages/languagefile.en.properties
@@ -134,6 +134,8 @@ FORMAT_CLASSPATH          = Class Path
 
 FORMAT_DN                 = DN: Distinguished Name
 
+FORMAT_DN_UPN             = Distinguished Name (DN), or User Principal Name (UPN)
+
 FORMAT_DOMAINNAME         = Domain name
 
 FORMAT_EMAILADDRESS       = E-mail address

--- a/modules/admin-gui/resources/languages/languagefile.fr.properties
+++ b/modules/admin-gui/resources/languages/languagefile.fr.properties
@@ -136,6 +136,8 @@ FORMAT_CLASSPATH          = Chemin de classe (class path)
 
 FORMAT_DN                 = DN : Nom distinctif
 
+FORMAT_DN_UPN             = Nom distinctif (DN) ou Nom principal d’utilisateur (UPN)
+
 FORMAT_DOMAINNAME         = Nom de domaine
 
 FORMAT_EMAILADDRESS       = Adresse électronique

--- a/modules/admin-gui/resources/sysconfig/editautoenrollmentconfiguration.xhtml
+++ b/modules/admin-gui/resources/sysconfig/editautoenrollmentconfiguration.xhtml
@@ -53,7 +53,7 @@
 				<h:panelGroup>
 					<h:inputText id="msaeForestRoot" disabled="#{autoenrollmentConfigMBean.viewOnly}"
 								 value="#{msAutoEnrollmentSettings.msaeForestRoot}" size="45"
-								 title="#{web.text.MSAE_FOREST_ROOT}">
+								 title="#{web.text.FORMAT_DOMAINNAME}">
 						<f:converter converterId="trimConverter"/>
 					</h:inputText>
 				</h:panelGroup>	            
@@ -66,7 +66,7 @@
 				<h:panelGroup>
 					<h:inputText id="msaeDomain" disabled="#{autoenrollmentConfigMBean.viewOnly}"
 								 value="#{msAutoEnrollmentSettings.msaeDomain}" size="45"
-								 title="#{web.text.DOMAINNAME}">
+								 title="#{web.text.FORMAT_DOMAINNAME}">
 						<f:converter converterId="trimConverter"/>
 					</h:inputText>
 				</h:panelGroup>
@@ -181,7 +181,7 @@
 				<h:panelGroup>
 					<h:inputText id="msaeAdLoginDN" disabled="#{autoenrollmentConfigMBean.viewOnly}"
 								 value="#{msAutoEnrollmentSettings.adLoginDN}" size="45"
-								 title="#{web.text.DOMAINNAME}">
+								 title="#{web.text.FORMAT_DN_UPN}">
 						<f:converter converterId="trimConverter"/>
 					</h:inputText>
 				</h:panelGroup>


### PR DESCRIPTION
Some field information (i.e. 'title' HTML tag) are bugged: bad message key, bad description, etc.
For better usability, in Admin GUI, these had been fixed.
It's a minor fix, but easy to review! ;-)