### PR TITLE
Fix calculation of maximumExpirationDate to renew certificate

### DIFF
--- a/modules/ejbca-ejb/src/org/ejbca/core/ejb/ca/auth/EndEntityAuthenticationSessionBean.java
+++ b/modules/ejbca-ejb/src/org/ejbca/core/ejb/ca/auth/EndEntityAuthenticationSessionBean.java
@@ -273,7 +273,7 @@ public class EndEntityAuthenticationSessionBean implements EndEntityAuthenticati
             if (eep == null) {
                 log.warn("End Entity Profile with ID " + userdata.getEndEntityProfileId() + " doesn't exist. Username: " + username);
             } else if (eep.isRenewDaysBeforeExpirationUsed()) {
-                final long maximumExpirationDate = System.currentTimeMillis() + eep.getRenewDaysBeforeExpiration()*24*60*60*1000;
+                final long maximumExpirationDate = System.currentTimeMillis() + (long) eep.getRenewDaysBeforeExpiration() *24*60*60*1000;
                 Date maxDate = new Date(maximumExpirationDate);
                 final Date now = new Date();
                 final Collection<Certificate> certs = certificateStoreSession.findCertificatesByUsernameAndStatusAfterExpireDate(


### PR DESCRIPTION
Fix implicit cast from int to Long that does not return valid results for the maximumExpirationDate, and therefore the configuration of Allow Renewal Before Expiration does not work properly.