### PR TITLE
L10n: Language metadata added in RA language files (in comments)

### DIFF
--- a/modules/ra-gui/resources/WEB-INF/classes/Messages_ar.properties
+++ b/modules/ra-gui/resources/WEB-INF/classes/Messages_ar.properties
@@ -11,13 +11,14 @@
 # *                                                                       *
 # *************************************************************************/
 #
-# version: $Id$
-#
-# Use UTF-8 (instead of the normally mandated ISO-8859-1) encoding of these ResourceBundle Strings.
+# Language name:    Arabic
+# Language code:    ar (ar-AE)
+# Native encoding:  UTF-8
+# EJBCA supported:  TEST ONLY
 #
 
-# TODO: This is sample file with no validity what so ever, but serves as an example of a RTL language.
-# Remove it or do a proper translation before release.
+### TEST: This is sample file with no validity what so ever, but serves as an example of a RTL language.
+### TODO: Remove it or do a proper translation before release.
 
 generic_title = EJBCA's RA GUI العربية
 generic_sampleText = رسالة نصية

--- a/modules/ra-gui/resources/WEB-INF/classes/Messages_de.properties
+++ b/modules/ra-gui/resources/WEB-INF/classes/Messages_de.properties
@@ -11,9 +11,10 @@
 # *                                                                       *
 # *************************************************************************/
 #
-# version: $Id$
-#
-# Use UTF-8 (instead of the normally mandated ISO-8859-1) encoding of these ResourceBundle Strings.
+# Language name:    German
+# Language code:    de (de-DE)
+# Native encoding:  UTF-8
+# EJBCA supported:  8.x
 #
 
 generic_title = EJBCA's RA GUI

--- a/modules/ra-gui/resources/WEB-INF/classes/Messages_en.properties
+++ b/modules/ra-gui/resources/WEB-INF/classes/Messages_en.properties
@@ -11,6 +11,10 @@
 # *                                                                       *
 # *************************************************************************/
 #
+# Language name:    English
+# Language code:    en (en-US)
+# Native encoding:  UTF-8
+# EJBCA supported:  8.x
 #
 # Use UTF-8 (instead of the normally mandated ISO-8859-1) encoding of these ResourceBundle Strings.
 #

--- a/modules/ra-gui/resources/WEB-INF/classes/Messages_sv.properties
+++ b/modules/ra-gui/resources/WEB-INF/classes/Messages_sv.properties
@@ -11,7 +11,11 @@
 # *                                                                       *
 # *************************************************************************/
 #
-# version: $Id$
+# Language name:    Swedish
+# Language code:    sv (sv-SE)
+# Native encoding:  UTF-8
+# EJBCA supported:  8.x
+#
 
 generic_title = EJBCA RA Webb
 enroll_validity_help_empty = Skriv in ett datum (yyyy-MM-dd [HH\:mm\:ss]) eller tidsintervall, t ex 1y (ett år), 6mo (sex månder) or 7d (en vecka).

--- a/modules/ra-gui/resources/WEB-INF/classes/Messages_vi.properties
+++ b/modules/ra-gui/resources/WEB-INF/classes/Messages_vi.properties
@@ -11,9 +11,10 @@
 # *                                                                       *
 # *************************************************************************/
 #
-# version: $Id$
-#
-# Use UTF-8 (instead of the normally mandated ISO-8859-1) encoding of these ResourceBundle Strings.
+# Language name:    Vietnamese
+# Language code:    vi (vi-VE)
+# Native encoding:  UTF-8
+# EJBCA supported:  8.x
 #
 
 generic_title = EJBCA's RA GUI


### PR DESCRIPTION
Just add some metadata in comments in RA language files, such as: Language name, Language code, Encoding.
It's easier to identify the right language file, than only the simple code in filename. That's all. No more, no less!