### PR TITLE
L10n: Add Document-Signing EKU in RA GUI (English)

### DIFF
--- a/modules/ra-gui/resources/WEB-INF/classes/Messages_en.properties
+++ b/modules/ra-gui/resources/WEB-INF/classes/Messages_en.properties
@@ -1014,6 +1014,7 @@ extendedkeyusage_1.3.6.1.5.5.7.3.17 = Internet Key Exchange for IPsec
 extendedkeyusage_1.3.6.1.5.5.7.3.20 = SIP Domain
 extendedkeyusage_1.3.6.1.5.5.7.3.21 = SSH Client
 extendedkeyusage_1.3.6.1.5.5.7.3.22 = SSH Server
+extendedkeyusage_1.3.6.1.5.5.7.3.36 = RFC9336 Document Signing
 extendedkeyusage_1.3.6.1.4.1.311.20.2.2 = MS Smart Card Logon
 extendedkeyusage_1.3.6.1.4.1.311.10.3.12 = MS Document Signing
 extendedkeyusage_1.3.6.1.4.1.311.2.1.21 = MS Individual Code Signing


### PR DESCRIPTION
Add the missing message "RFC9336 Document Signing" (OID: 1.3.6.1.5.5.7.3.36) in RA GUI English language file