### PR TITLE
Edit End Entity: reorder buttons, so Revoke And Delete is not the default action

### DIFF
--- a/modules/ra-gui/resources/resources/component/eedetails.xhtml
+++ b/modules/ra-gui/resources/resources/component/eedetails.xhtml
@@ -992,20 +992,20 @@
             <h:outputText styleClass="#{cc.attrs.styleFull} pre" value=" " />
 
             <h:panelGroup styleClass="pure-u-2-3 ra-endEntityNavEditBar">
-                <h:commandButton action="#{raEndEntityBean.revokeCertificatesAndDeleteEndEntity}"
-                                 value="#{msg.endentity_page_command_edit_revoke_delete}"
-                                 styleClass="pure-button ra-button ra-endEntityEditSaveCancel"
-                                 rendered="#{raAccessBean.authorizedToEditEndEntities and raEndEntityBean.editEditEndEntityMode and raEndEntityBean.apiEditCompatible}" />
                 <h:commandButton action="#{raEndEntityBean.editEditEndEntity}"
                                  value="#{msg.endentity_page_command_edit}"
                                  styleClass="pure-button ra-button ra-endEntityEditSaveCancel"
                                  rendered="#{not raEndEntityBean.deleted and raAccessBean.authorizedToEditEndEntities and !raEndEntityBean.editEditEndEntityMode and raEndEntityBean.apiEditCompatible and raEndEntityBean.endEntity != null}" />
+                <h:commandButton action="#{raEndEntityBean.editEditEndEntitySave}"
+                                 value="#{msg.endentity_page_command_editsave}"
+                                 styleClass="pure-button ra-button ra-endEntityEditSaveCancel"
+                                 rendered="#{raAccessBean.authorizedToEditEndEntities and raEndEntityBean.editEditEndEntityMode and raEndEntityBean.apiEditCompatible}" />
                 <h:commandButton action="#{raEndEntityBean.editEditEndEntityCancel}"
                                  value="#{msg.endentity_page_command_editcancel}"
                                  styleClass="pure-button ra-button ra-endEntityEditSaveCancel"
                                  rendered="#{raAccessBean.authorizedToEditEndEntities and raEndEntityBean.editEditEndEntityMode and raEndEntityBean.apiEditCompatible}" />
-                <h:commandButton action="#{raEndEntityBean.editEditEndEntitySave}"
-                                 value="#{msg.endentity_page_command_editsave}"
+                <h:commandButton action="#{raEndEntityBean.revokeCertificatesAndDeleteEndEntity}"
+                                 value="#{msg.endentity_page_command_edit_revoke_delete}"
                                  styleClass="pure-button ra-button ra-endEntityEditSaveCancel"
                                  rendered="#{raAccessBean.authorizedToEditEndEntities and raEndEntityBean.editEditEndEntityMode and raEndEntityBean.apiEditCompatible}" />
                 <h:commandButton action="#{raEndEntityBean.backToSearch}" value="#{msg.search_ees_page_cdclose_command}"


### PR DESCRIPTION
`<h:commandButton>` gets rendered as `<input type=submit>`. Pressing the Enter key in an input field on an form with multiple submit buttons is equivalent to clicking the first one. Up to now, the default action of the Edit End Entity form was the dangerous operation "Revoke certificates and delete end entity." It is probably more likely that the user intended to save changes instead, which is the action that is now the default (executed when pressing Enter).

This fixes #430. The new button order looks like this:

![image](https://github.com/Keyfactor/ejbca-ce/assets/54625981/c9be9c41-c5c7-4e7b-94fa-676ab2302d7c)
