### PR TITLE
Fix: Add back favicon to Add End-Entity web page (in Admin GUI)

### DIFF
--- a/modules/admin-gui/resources/ra/addendentity.jsp
+++ b/modules/admin-gui/resources/ra/addendentity.jsp
@@ -773,7 +773,7 @@
 <head>
   <title><c:out value="<%= globalconfiguration.getEjbcaTitle() %>" /></title>
   <link rel="stylesheet" type="text/css" href="<c:out value='<%= ejbcawebbean.getBaseUrl() + ejbcawebbean.getCssFile() %>' />" />
-  <link rel="shortcut icon" href="<%=ejbcawebbean.getAdminWebBaseUrl() + ejbcawebbean.getImagePath("favicon.png")%>" type="image/png" />
+  <link rel="shortcut icon" href="<%=ejbcawebbean.getAdminWebBaseUrl() + ejbcawebbean.getImagePath(ejbcawebbean.getEditionFolder() + "/favicon.png")%>" type="image/png" />
   <script type="text/javascript">
 
   <% if(!noprofiles){ %>


### PR DESCRIPTION
The "Add End-Entity" web page (from Admin GUI) has lost its favicon!
Action: Add back the favicon of the "Add End-Entity" web page.