### PR TITLE
L10n: Admin GUI English fix (from version 8.2.0)

### DIFF
--- a/modules/admin-gui/resources/languages/languagefile.en.properties
+++ b/modules/admin-gui/resources/languages/languagefile.en.properties
@@ -513,7 +513,11 @@ CRYPTOTOKEN_ATTRFILE      = Attribute File
 
 CRYPTOTOKEN_AUTO          = Auto-activation
 
+CRYPTOTOKEN_AWSKMS_ACCESSKEYID = Access KeyID
+
 CRYPTOTOKEN_AWSKMS_AUTH   = AWS KMS Authentication Type
+
+CRYPTOTOKEN_AWSKMS_REGION = Region
 
 CRYPTOTOKEN_CANCEL        = Cancel
 
@@ -536,10 +540,6 @@ CRYPTOTOKEN_KEYVAULT_TYPE = Key Vault Type
 CRYPTOTOKEN_KEYVAULT_USE_BINDING = Key Vault Public Key Authentication
 
 CRYPTOTOKEN_KEYVAULT_BINDING = Key Vault Key Binding Name
-
-CRYPTOTOKEN_AWSKMS_REGION = Region
-
-CRYPTOTOKEN_AWSKMS_ACCESSKEYID = Access KeyID
 
 CRYPTOTOKEN_KPM_ACTION    = Action
 
@@ -663,6 +663,7 @@ AZUREAUTHENTICATIONTYPE.MANAGED_IDENTITY = Azure Managed Identity
 CRYPTOTOKEN_FORTANIX_BASE_ADDRESS = Fortanix Base Address
 AWSKMSAUTHENTICATIONTYPE.KEY_ID_AND_SECRET = Access Key ID and Secret
 AWSKMSAUTHENTICATIONTYPE.SERVICE_ACCOUNT_ROLE = Service Account Role
+
 
 ### Internal Key Bindings
 
@@ -994,9 +995,9 @@ DN_PKIX_EMAILADDRESS        = emailAddress, E-mail address in DN
 
 DN_PKIX_EMAILADDRESS_HELP   = See also configuration of E-mail field.
 
-DN_PKIX_UID                 = userid
+DN_PKIX_UID                 = UID, User identifier
 
-DN_PKIX_UNIQUEIDENTIFIER    = uniqueIdentifier
+DN_PKIX_UNIQUEIDENTIFIER    = uniqueIdentifier, Unique identifier
 
 DN_PKIX_COMMONNAME          = CN, Common name
 
@@ -1082,7 +1083,7 @@ EKU_MS_EFSCRYPTO            = MS Encrypted File System (EFS)
 
 EKU_MS_EFSRECOVERY          = MS EFS Recovery
 
-EKU_MS_CA_EXCHANGE          = MS CA Key Exchange Certificate
+EKU_MS_CA_EXCHANGE          = MS CA Key Exchange
 
 EKU_NIST_PIVCARDAUTH        = PIV Card Authentication
 
@@ -1753,7 +1754,7 @@ WITH_STATEORPROVINCE      = ST, State or Province
 
 WITH_TITLE                = title, Title
 
-WITH_UID                  = UID, Unique ID
+WITH_UID                  = UID, User identifier
 
 WITH_UPN                  = MS UPN, User Principal Name
 
@@ -1860,7 +1861,7 @@ ARLATTRIBUTE              = ARL Attribute
 
 AVAILABLEBITLENGTHS       = Available Bit Lengths
 
-AVAILABLESECURITYLEVEL   = Available Security Levels
+AVAILABLESECURITYLEVEL    = Available Security Levels
 
 AVAILABLECAS              = Available CAs
 
@@ -2455,7 +2456,7 @@ OLDMANUALCLASSPATHELP     = * Old, manual (not auto-detected) class path. To all
 
 ONEAVAILABLEBITLENGTH     = At least one available bit length must be selected.
 
-ONEAVAILABLESECURITYLEVEL     = At least one available security level must be selected.
+ONEAVAILABLESECURITYLEVEL = At least one available security level must be selected.
 
 ONEAVAILABLEKEYALGORITHM  = At least one available key algorithm must be selected.
 
@@ -2889,7 +2890,7 @@ CLEARALLCACHES            = Clear All Caches
 
 CLEARALLCACHES_EXCLUDE_CRYPTOTOKEN_CACHE = Exclude Active Manually-Activated CryptoTokens
 
-CLEARALLCACHES_HELP1      = Clear all the caches on all nodes. The following caches are cleared: Global Configuration Cache, CMP Configurations Cache, SCEP Configuration Cache, End Entity Profile Cache, Certificate Profile Cache, Authorization Cache, CA Cache, CryptoToken Cache, Publisher Cache, Internal KeyBinding Cache, OCSP Signer Cache, OCSP Extensions Cache, CT Caches and Certificate Store Cache, Key Exchange Certificate (MS Auto Enrolment) Cache.
+CLEARALLCACHES_HELP1      = Clear all the caches on all nodes. The following caches are cleared: Global Configuration Cache, CMP Configurations Cache, SCEP Configuration Cache, End Entity Profile Cache, Certificate Profile Cache, Authorization Cache, CA Cache, CryptoToken Cache, Publisher Cache, Internal KeyBinding Cache, OCSP Signer Cache, OCSP Extensions Cache, CT Caches, Certificate Store Cache, and Key Exchange Certificate (MS Auto-Enrollment) Cache.
 
 CLEARALLCACHES_HELP2      = Note that after clearing the cache, if not excluded, all CryptoTokens that are manually activated will go off-line.
 
@@ -2947,7 +2948,7 @@ REDACT_SUBJECT             = Redact Subject Name from logs
 
 REDACT_SUBJECT_DEFAULT     = Redact Subject Name when End Entity Profile data is unavailable
 
-REDACTPIIDEFAULT_HELP     = These scenarios include and are not exhaustive to operations in remote peers, EMPTY end entity profile, certain exception stack traces etc
+REDACTPIIDEFAULT_HELP     = These scenarios include and are not exhaustive to operations in remote peers, EMPTY end entity profile, certain exception stack traces, etc.
 
 REDACT_SUBJECT_ENFORCED   = Always redact Subject Name irrespective for End Entity Profile settings
 
@@ -4628,7 +4629,7 @@ MATCHSURNAME              = surname, Family name
 
 MATCHTITLE                = title, Title
 
-MATCHUID                  = UID, Unique ID
+MATCHUID                  = UID, User identifier
 
 MATCHUPN                  = MS UPN, User Principal Name
 

--- a/modules/admin-gui/resources/languages/languagefile.en.properties
+++ b/modules/admin-gui/resources/languages/languagefile.en.properties
@@ -845,7 +845,7 @@ ALT_PKIX_UNIFORMRESOURCEID  = Uniform Resource Identifier (URI)
 
 ALT_PKIX_X400ADDRESS        = X.400 Address
 
-ALT_PKIX_XMPPADDR           = XmppAddr
+ALT_PKIX_XMPPADDR           = XMPP Address
 
 #-- Certificate fields
 
@@ -985,9 +985,9 @@ DN_JURISDICTION_STATE       = Jurisdiction State or Province [EV Certificate]
 
 DN_JURISDICTION_COUNTRY     = Jurisdiction Country (ISO 3166) [EV Certificate]
 
-DN_MATTER_VID               = Matter VID
+DN_MATTER_VID               = VID, Vendor identifier (Matter)
 
-DN_MATTER_PID               = Matter PID
+DN_MATTER_PID               = PID, Product identifier (Matter)
 
 DN_PKIX_DESCRIPTION         = description, Description
 


### PR DESCRIPTION
Some fixes for Admin GUI English, from version 8.2.0.

Remarks:
- UID means "User identifier", not "Unique ID"
- EKU_MS_CA_EXCHANGE is a usage not an object: replace "MS CA Key Exchange Certificate" by "MS CA Key Exchange"
- minor typos