### PR TITLE
Fix: RA GUI Make Request - Bug with Focus and Duplication

### DIFF
--- a/modules/ra-gui/resources/enrollmakenewrequest.xhtml
+++ b/modules/ra-gui/resources/enrollmakenewrequest.xhtml
@@ -645,7 +645,7 @@
 								value="#{enrollMakeNewRequestBean.subjectDirectoryAttributes.requiredFieldInstances}"
 								var="instance">
 								<h:panelGroup layout="block" styleClass="pure-control-group">
-									<h:outputLabel for="subjectDirectoryField"
+									<h:outputLabel for="subjectDirectoryNonModifiableField"
 										value="#{msg['subject_directory_attributes_'.concat(instance.name)]} = "
 										rendered="#{instance.required and !instance.modifiable}" />
 									<h:outputLabel for="subjectDirectoryField"
@@ -663,11 +663,10 @@
 										<f:ajax event="keyup" execute="@this"
 											render=":requestInfoForm:requestPreviewOuterPanel subjectDirectoryAttributesMessage"/>
 									</h:inputText>
-									<h:outputLabel for="subjectDirectoryNonModifiableField"
-										value="#{msg['subject_directory_attributes_'.concat(instance.name)]} = "
-										rendered="#{!instance.modifiable and instance.required}" />
-									<h:outputText id="subjectDirectoryNonModifiableField" rendered="#{!instance.modifiable and instance.required}" value="#{instance.value}" style="color:white;"/>
-									<h:selectOneMenu value="#{instance.value}" rendered="#{instance.selectable}" styleClass="jsAutoFocusFirst">
+									<h:outputLabel id="subjectDirectoryFieldNonModifiableLabel" value="#{instance.value}"
+										 rendered="#{!instance.modifiable and !instance.selectable}" styleClass="pure-control-group label" style="text-align: left">
+									</h:outputLabel>
+									<h:selectOneMenu id="subjectDirectoryNonModifiableField" value="#{instance.value}" rendered="#{instance.selectable}" styleClass="jsAutoFocusFirst">
 										<f:selectItems value="#{instance.selectableValues}" />
 										<f:attribute name="_label" value="#{instance.name}"/>
 										<f:ajax event="change" execute="@this"


### PR DESCRIPTION
In RA GUI, function Make Request, section "Required Subject Directory Attributes", there is a display bug (and HTML 'label' bug) with Required and Non Modifiable SDA attributes.
And, when click on a Required and Non Modifiable selectable list SDA attribute name, there is no focus on the list.
Screenshot **with the bug**
![2024-01-11 - EJBCA RA GUI - Make Request - Required SDA - BUG](https://github.com/Keyfactor/ejbca-ce/assets/43141830/cde17397-5276-4c6b-8f38-a503d603af71)
Screenshot **with the fix**
![2024-01-11 - EJBCA RA GUI - Make Request - Required SDA - FIX](https://github.com/Keyfactor/ejbca-ce/assets/43141830/36035ce2-bed2-4cf7-8dfa-290e243283c5)

**Reproduce:**
- create Certificate Profile with Subject Directory Attributes (SDA) checked
- create End-Entity Profile with Subject Directory Attributes (SDA): **Required** and **Non Modifiable** (with fixed text 'Hello', or selectable list 'Toto;Titi', is the same bug)
- go to RA GUI > Make Request
- select the End-Entity Profile above, then look at SDA bug

**Info:**
To fix it (duplication bug, and focus bug), I used a similar code than required DN attributes one.