### PR TITLE
Fix merge DNs with SANs

### DIFF
--- a/modules/ejbca-common/src/org/ejbca/core/model/ra/EndEntityInformationFiller.java
+++ b/modules/ejbca-common/src/org/ejbca/core/model/ra/EndEntityInformationFiller.java
@@ -545,7 +545,8 @@ public class EndEntityInformationFiller {
     
     private static String getBcNameStyle(String parameter, String entityType) {
         if(entityType.equals(SUBJECT_ALTERNATIVE_NAME)) {
-            return parameter;
+            // The SAN's type name needs to be UPPERCASE, so it matches with the EE policy. 
+            return parameter.toUpperCase(Locale.ROOT);
         }
         return BC_STYLE_PARAMETERS.getOrDefault(parameter.toUpperCase(Locale.ROOT), parameter.toUpperCase(Locale.ROOT));
     }

--- a/modules/ejbca-ejb/src-test/org/ejbca/core/model/ra/EndEntityInformationFillerTest.java
+++ b/modules/ejbca-ejb/src-test/org/ejbca/core/model/ra/EndEntityInformationFillerTest.java
@@ -655,17 +655,17 @@ public class EndEntityInformationFillerTest {
         user.setSubjectAltName(san+",directoryName=CN=XX\\,O=YY");
         EndEntityInformationFiller.fillUserDataWithDefaultValues(user, p);
         assertEquals("DNSNAME=foo.bar.com,DNSNAME=foo1.bar.com,DNSNAME=server.bad.com,"
-                + "DNSNAME=server.superbad.com,RFC822NAME=foo@bar.com,RFC822NAME=myEmail@dom.com,directoryName=CN=XX\\,O=YY", user.getSubjectAltName());
+                + "DNSNAME=server.superbad.com,RFC822NAME=foo@bar.com,RFC822NAME=myEmail@dom.com,DIRECTORYNAME=CN=XX\\,O=YY", user.getSubjectAltName());
         
         user.setSubjectAltName(san+",directoryName=CN=XX\\,O=YY\\,C=DE");
         EndEntityInformationFiller.fillUserDataWithDefaultValues(user, p);
         assertEquals("DNSNAME=foo.bar.com,DNSNAME=foo1.bar.com,DNSNAME=server.bad.com,"
-                + "DNSNAME=server.superbad.com,RFC822NAME=foo@bar.com,RFC822NAME=myEmail@dom.com,directoryName=CN=XX\\,O=YY\\,C=DE", user.getSubjectAltName());
+                + "DNSNAME=server.superbad.com,RFC822NAME=foo@bar.com,RFC822NAME=myEmail@dom.com,DIRECTORYNAME=CN=XX\\,O=YY\\,C=DE", user.getSubjectAltName());
         
         user.setSubjectAltName(san+",directoryName=CN=XX\\,O=YY");
         EndEntityInformationFiller.fillUserDataWithDefaultValues(user, p);
         assertEquals("DNSNAME=foo.bar.com,DNSNAME=foo1.bar.com,DNSNAME=server.bad.com,"
-                + "DNSNAME=server.superbad.com,RFC822NAME=foo@bar.com,RFC822NAME=myEmail@dom.com,directoryName=CN=XX\\,O=YY", user.getSubjectAltName());
+                + "DNSNAME=server.superbad.com,RFC822NAME=foo@bar.com,RFC822NAME=myEmail@dom.com,DIRECTORYNAME=CN=XX\\,O=YY", user.getSubjectAltName());
         
         // URI may include + and = in queryparam, this functionality ensures input=output
         // for single valued RDNs(not multi value)
@@ -674,28 +674,28 @@ public class EndEntityInformationFillerTest {
         EndEntityInformationFiller.fillUserDataWithDefaultValues(user, p);
         assertEquals("DNSNAME=foo.bar.com,DNSNAME=foo1.bar.com,DNSNAME=server.bad.com,"
                 + "DNSNAME=server.superbad.com,RFC822NAME=foo@bar.com,RFC822NAME=myEmail@dom.com,"
-                + "uniformResourceId=http://xxx.de/en?que\\=res", user.getSubjectAltName());
+                + "UNIFORMRESOURCEID=http://xxx.de/en?que\\=res", user.getSubjectAltName());
         
         user.setSubjectAltName(san+",uniformResourceIdentifier=http://xxx.de/en?que=res");
         EndEntityInformationFiller.fillUserDataWithDefaultValues(user, p);
         assertEquals("DNSNAME=foo.bar.com,DNSNAME=foo1.bar.com,DNSNAME=server.bad.com,"
                 + "DNSNAME=server.superbad.com,RFC822NAME=foo@bar.com,RFC822NAME=myEmail@dom.com,"
-                + "uniformResourceIdentifier=http://xxx.de/en?que=res", user.getSubjectAltName());
+                + "UNIFORMRESOURCEIDENTIFIER=http://xxx.de/en?que=res", user.getSubjectAltName());
         
         user.setSubjectAltName(san+",uniformResourceId=http://xxx.de/en?que\\=res\\+q2\\=r2");
         EndEntityInformationFiller.fillUserDataWithDefaultValues(user, p);
         assertEquals("DNSNAME=foo.bar.com,DNSNAME=foo1.bar.com,DNSNAME=server.bad.com,"
                 + "DNSNAME=server.superbad.com,RFC822NAME=foo@bar.com,RFC822NAME=myEmail@dom.com,"
-                + "uniformResourceId=http://xxx.de/en?que\\=res\\+q2\\=r2", user.getSubjectAltName());
+                + "UNIFORMRESOURCEID=http://xxx.de/en?que\\=res\\+q2\\=r2", user.getSubjectAltName());
         
         user.setSubjectAltName(san+",uniformResourceId=http://xxx.de/en?que=res+q2=r2,1.2.3.4=qwerty");
         EndEntityInformationFiller.fillUserDataWithDefaultValues(user, p);
         assertEquals("DNSNAME=foo.bar.com,DNSNAME=foo1.bar.com,DNSNAME=server.bad.com,"
                 + "DNSNAME=server.superbad.com,RFC822NAME=foo@bar.com,RFC822NAME=myEmail@dom.com,"
-                + "uniformResourceId=http://xxx.de/en?que=res+q2=r2,1.2.3.4=qwerty", user.getSubjectAltName());
+                + "UNIFORMRESOURCEID=http://xxx.de/en?que=res+q2=r2,1.2.3.4=qwerty", user.getSubjectAltName());
         
     }
-    
+	
     @Test
     public void testUniqueEntriesSan() throws Exception {
         EndEntityProfile p = new EndEntityProfile();


### PR DESCRIPTION
Noticed some issues when importing certificates which included SANs. The EE Policy I was using had the 'Allow Merge DNs across all interfaces" activated. I thought this setting only affected the Subject DN, but it turns out it also affects SANs (Note: This should be mentioned in the documentation).

The error when importing a certificate was:
ERROR: org.ejbca.core.model.ra.raadmin.EndEntityProfileValidationException: Wrong number of DNSNAME fields in Subject Alternative Name.

There is a DEBUG message that helped to understand the issue:
DEBUG [org.ejbca.core.model.ra.EndEntityInformationFiller] (default task-5) merged dn: DNSNAME=test.org.au,dNSName=test.org.au
Note that 'merged dn' has two entries with the same value, but one is referenced/keyed as "DNSNAME" and the other "dNSName".

The code at EndEntityInformationFiller.mergedDnString() is adding the SAN's default value from the EE Policy as "DNSNAME", and then adding the SAN's value from the certificate as "dNSName". As these strings are different case, this is preventing the code to merge properly.

A fix to this issue is to ensure the 'key' string is made UPPERCASE, so the "dNSNAME" becomes "DNSNAME". This is quite easy as there is a 'getBcNameStyle()' method which is easily modified.

Tests also included in this change.