### PR TITLE
Fix to issue Link Certificate using previous Signature Algorithm

### DIFF
--- a/modules/ejbca-ejb/src/org/ejbca/core/ejb/ca/caadmin/CAAdminSessionBean.java
+++ b/modules/ejbca-ejb/src/org/ejbca/core/ejb/ca/caadmin/CAAdminSessionBean.java
@@ -2345,19 +2345,14 @@ public class CAAdminSessionBean implements CAAdminSessionLocal, CAAdminSessionRe
             // Set the new certificate chain that we have created above
             ca.setCertificateChain(cachain);
             
-            // In the case that the CA's signature algorithm was changed in the renewal, then the link certificate will need to 
-            // be signed using the previous signature algorithm.
-            final String currentSigAlg = caToken.getSignatureAlgorithm();
+            // The signature algorithm on a link certificate shall always be from the "old" CA, i.e. the same algorithm as was 
+            // used to sign the old CA certificate
             final String previousSigAlg = CertTools.getCertSignatureAlgorithmNameAsString(oldCaCertificate);
-            final CertificateProfile linkCertProfile = certprofile.clone();
-            if (!StringUtils.equalsIgnoreCase(currentSigAlg, previousSigAlg)) {
-                log.info("CA signature algorithm change detected. Link certificate will use the signature algorithm "+previousSigAlg+".");
-                // Since caToken.getSignatureAlgorithms changed to a new algorithm, we need to clone the certificate profile and 
-                // temporarily use the cloned profile with the old signature algorithm set, only for creating the link certificate.
-                //caToken.setSignatureAlgorithm(sPreviousSigAlg);
-                // This works because certProfile.getSignatureAlgorithm takes presedence before caToken.getSignatureAlgorithm
-                linkCertProfile.setSignatureAlgorithm(previousSigAlg);
+            if (log.isDebugEnabled()) {
+                log.debug("Signature algorithm for link certificate (if issued) for CA '" + ca.getName() + "' will use the old CA certificate signature algorithm "+previousSigAlg+".");
             }
+            final CertificateProfile linkCertProfile = certprofile.clone();
+            linkCertProfile.setSignatureAlgorithm(previousSigAlg);
             // We need to save the CAID, for audit logging that the CA has changed as subjectDN change means a change of CAId
             int caidBeforeNameChange = -1;
             if (subjectDNWillBeChanged) {

--- a/modules/ejbca-ejb/src/org/ejbca/core/ejb/ca/caadmin/CAAdminSessionBean.java
+++ b/modules/ejbca-ejb/src/org/ejbca/core/ejb/ca/caadmin/CAAdminSessionBean.java
@@ -2360,21 +2360,24 @@ public class CAAdminSessionBean implements CAAdminSessionLocal, CAAdminSessionRe
 
             // We need to save all this, audit logging that the CA is changed
             int caidBeforeNameChange = -1;
-            if (subjectDNWillBeChanged) {
-                ((X509CA) ca).createOrRemoveLinkCertificateDuringCANameChange(cryptoToken, createLinkCertificate, certprofile, cceConfig, oldCaCertificate);
-                caidBeforeNameChange = caid;
-                caid = CAData.calculateCAId(newSubjectDN); // recalculate the caid to corresponds to new CA
-                ca.setCAId(caid); // it was set to 0 above
-                caSession.addCA(authenticationToken, ca); //add new CA into database
-            } else {
-                ca.createOrRemoveLinkCertificate(cryptoToken, createLinkCertificate, certprofile, cceConfig, oldCaCertificate);
-                caSession.editCA(authenticationToken, ca, true);
-            }
-            
-            // Put the Signature Algorthm settings back if we changed them to issue the Link certificate.
-            if (bChangedSigAlg) {
-                caToken.setSignatureAlgorithm(sCurrentSigAlg);
-                certprofile.setSignatureAlgorithm(sCurrentSigAlg);
+            try {
+                if (subjectDNWillBeChanged) {
+                    ((X509CA) ca).createOrRemoveLinkCertificateDuringCANameChange(cryptoToken, createLinkCertificate, certprofile, cceConfig,
+                            oldCaCertificate);
+                    caidBeforeNameChange = caid;
+                    caid = CAData.calculateCAId(newSubjectDN); // recalculate the caid to corresponds to new CA
+                    ca.setCAId(caid); // it was set to 0 above
+                    caSession.addCA(authenticationToken, ca); //add new CA into database
+                } else {
+                    ca.createOrRemoveLinkCertificate(cryptoToken, createLinkCertificate, certprofile, cceConfig, oldCaCertificate);
+                    caSession.editCA(authenticationToken, ca, true);
+                } 
+            } finally {
+                // Put the Signature Algorithm settings back if we changed them to issue the Link certificate.
+                if (bChangedSigAlg) {
+                    caToken.setSignatureAlgorithm(sCurrentSigAlg);
+                    certprofile.setSignatureAlgorithm(sCurrentSigAlg);
+                }
             }
 
             // Publish the new CA certificate

--- a/modules/systemtests/src-test/org/ejbca/core/ejb/ca/caadmin/RenewCATest.java
+++ b/modules/systemtests/src-test/org/ejbca/core/ejb/ca/caadmin/RenewCATest.java
@@ -104,7 +104,8 @@ public class RenewCATest extends CaTestCase {
     **/
     
     // Need these extra EJBs
-    private final CryptoTokenManagementSessionRemote cryptoTokenManagementSession = EjbRemoteHelper.INSTANCE.getRemoteSession(CryptoTokenManagementSessionRemote.class);
+    private final CryptoTokenManagementSessionRemote cryptoTokenManagementSession = EjbRemoteHelper.INSTANCE
+            .getRemoteSession(CryptoTokenManagementSessionRemote.class);
     private final CertificateProfileSessionRemote certificateProfileSession = EjbRemoteHelper.INSTANCE
             .getRemoteSession(CertificateProfileSessionRemote.class);
 
@@ -166,7 +167,7 @@ public class RenewCATest extends CaTestCase {
         byte[] linkCertificateAfterRenewal1Bytes = caAdminSession.getLatestLinkCertificate(newinfo.getCAId());
         assertTrue("There is no available link certificate after CA renewal with EC key", linkCertificateAfterRenewal1Bytes != null);
         @SuppressWarnings("deprecation")
-        X509Certificate linkCertificateAfterRenewal1 = (X509Certificate) CertTools.getCertfromByteArray(linkCertificateAfterRenewal1Bytes);
+        X509Certificate linkCertificateAfterRenewal1 = (X509Certificate) com.keyfactor.util.CertTools.getCertfromByteArray(linkCertificateAfterRenewal1Bytes);
         assertTrue("The Link certificate should be signed by the CA's previous signing algorithm, not "+linkCertificateAfterRenewal1.getSigAlgName(),
                 linkCertificateAfterRenewal1.getSigAlgName().equalsIgnoreCase(sPreviousSigAlg) );
 

--- a/modules/systemtests/src-test/org/ejbca/core/ejb/ca/caadmin/RenewCATest.java
+++ b/modules/systemtests/src-test/org/ejbca/core/ejb/ca/caadmin/RenewCATest.java
@@ -28,6 +28,7 @@ import org.cesecore.certificates.ca.CAConstants;
 import org.cesecore.certificates.ca.CaSessionRemote;
 import org.cesecore.certificates.ca.X509CAInfo;
 import org.cesecore.certificates.ca.catoken.CAToken;
+import org.cesecore.certificates.certificate.InternalCertificateStoreSessionRemote;
 import org.cesecore.certificates.certificateprofile.CertificateProfileConstants;
 import org.cesecore.certificates.certificateprofile.CertificateProfileSessionRemote;
 import org.cesecore.keys.token.CryptoTokenManagementSessionRemote;
@@ -60,7 +61,8 @@ public class RenewCATest extends CaTestCase {
     private ServiceSessionRemote serviceSession = EjbRemoteHelper.INSTANCE.getRemoteSession(ServiceSessionRemote.class);
     private final CryptoTokenManagementSessionRemote cryptoTokenManagementSession = EjbRemoteHelper.INSTANCE.getRemoteSession(CryptoTokenManagementSessionRemote.class);
     private final CertificateProfileSessionRemote certificateProfileSession = EjbRemoteHelper.INSTANCE.getRemoteSession(CertificateProfileSessionRemote.class);
-
+    private static GlobalConfigurationSessionRemote globalConfigSession = EjbRemoteHelper.INSTANCE.getRemoteSession(GlobalConfigurationSessionRemote.class);
+    private final InternalCertificateStoreSessionRemote internalCertificateStoreSession = EjbRemoteHelper.INSTANCE.getRemoteSession(InternalCertificateStoreSessionRemote.class, EjbRemoteHelper.MODULE_TEST);
     
     @Before
     public void setUp() throws Exception {
@@ -168,12 +170,129 @@ public class RenewCATest extends CaTestCase {
         byte[] linkCertificateAfterRenewal1Bytes = caAdminSession.getLatestLinkCertificate(newinfo.getCAId());
         assertTrue("There is no available link certificate after CA renewal with EC key", linkCertificateAfterRenewal1Bytes != null);
         @SuppressWarnings("deprecation")
-        X509Certificate linkCertificateAfterRenewal1 = (X509Certificate) com.keyfactor.util.CertTools.getCertfromByteArray(linkCertificateAfterRenewal1Bytes);
-        assertTrue("The Link certificate should be signed by the CA's previous signing algorithm, not "+linkCertificateAfterRenewal1.getSigAlgName(),
-                linkCertificateAfterRenewal1.getSigAlgName().equalsIgnoreCase(sPreviousSigAlg) );
+        X509Certificate linkCertificateAfterRenewal = (X509Certificate) com.keyfactor.util.CertTools.getCertfromByteArray(linkCertificateAfterRenewal1Bytes);
+        assertTrue("The Link certificate should be signed by the CA's previous signing algorithm, not "+linkCertificateAfterRenewal.getSigAlgName(),  linkCertificateAfterRenewal.getSigAlgName().equalsIgnoreCase(sPreviousSigAlg) );
+
+        // Check the SignatureAlgorithm on the CA's Token is still set correctly
+        assertTrue("The signature algorithm on the CA's token was changed and should not be "+caToken.getSignatureAlgorithm(), caToken.getSignatureAlgorithm().equals(AlgorithmConstants.SIGALG_SHA256_WITH_ECDSA));
+
+        // Check the Signature Algorithm on the CertPolicy is still set correctly
+        assertTrue("The signature algorithm on the CA's certificate profile was changed and should not be "+cpCA.getSignatureAlgorithm(), cpCA.getSignatureAlgorithm().equals(AlgorithmConstants.SIGALG_SHA256_WITH_ECDSA));
+
+        // Check the Link cert's IssuerDN matches the original CA's SubjectDN 
+        assertTrue("The IssuerDN of the Link certificate does not match the SubjectDN of the original CA certificate.", linkCertificateAfterRenewal.getIssuerDN().equals( orgcert.getSubjectDN()));
+
+        // Check the Link cert's SubjectDN matches the original CA's SubjectDN 
+        // Note: There was not a Name change occurring
+        assertTrue("The SubjectDN of the Link certificate does not match the SubjectDN of the original CA certificate.", linkCertificateAfterRenewal.getSubjectDN().equals( orgcert.getSubjectDN()));
 
         // Test done!
         log.trace("<testrenewCA_ChangeKeyAlg()");
+    }
+
+        
+    /** Test renewal of a CA using a different key algorithm and a different SubjectDN. 
+     *  Note: Can run these tests alone by using: ant test:runone -Dtest.runone=RenewCATest
+    **/
+    @Test
+    public void testrenewCA_ChangeKeyAlgWithNameChange() throws Exception {
+        log.trace(">testrenewCA_ChangeKeyAlgWithNameChange()");
+
+        // Ensure the NameChange setting is true
+        GlobalConfiguration globalConfiguration = (GlobalConfiguration) globalConfigSession
+                .getCachedConfiguration(GlobalConfiguration.GLOBAL_CONFIGURATION_ID);
+        boolean backupEnableIcaoCANameChangeValue = globalConfiguration.getEnableIcaoCANameChange();
+        globalConfiguration.setEnableIcaoCANameChange(true);
+        globalConfigSession.saveConfiguration(internalAdmin, globalConfiguration);
+        
+        X509CAInfo info = (X509CAInfo) caSession.getCAInfo(internalAdmin, getTestCAName());
+        X509Certificate orgcert = (X509Certificate) info.getCertificateChain().iterator().next();
+        // Sleep at least for one second so we are not so fast that we create a new cert with the same time
+        Thread.sleep(2000);
+        
+        // Prepare to renew CA but with an EC key
+        
+        // Get the CA's token
+        final CAToken caToken = info.getCAToken();
+        
+        // The current Signing Algorithm should be RSA-based
+        String sPreviousSigAlg = ((X509Certificate)orgcert).getSigAlgName();
+        assertTrue("Current CA's Signature Algorithm should include RSA", sPreviousSigAlg.contains("RSA"));
+
+        // Set the next key alias for the token
+        String sNextKeyAlias = "TestEC";
+        
+        // Create an EC key. Need the CryptoTokeManagementSession for this
+        cryptoTokenManagementSession.createKeyPair(internalAdmin, caToken.getCryptoTokenId(), sNextKeyAlias, com.keyfactor.util.keys.token.KeyGenParams.builder("prime256v1").build());
+
+        // To get EJBCA to renew a CA with a different key algorithm, we need to:
+        //   1. set up the signing algorithm in the CA's token to support EC, 
+        //   2. ensure the certificate profile has an appropriate signature algorithm to support EC.
+        
+        // Set the signature algorithm of the token
+        caToken.setSignatureAlgorithm( AlgorithmConstants.SIGALG_SHA256_WITH_ECDSA);
+        
+        // Need to set the Certificate Profile to use ECDSA based signature algorithm
+        // Lets copy the current profile, change it, and save a new profile (as we can't edit the current profile)
+        int iCP = info.getCertificateProfileId();
+        org.cesecore.certificates.certificateprofile.CertificateProfile cpCA = certificateProfileSession.getCertificateProfile(iCP);
+        cpCA.setSignatureAlgorithm( AlgorithmConstants.SIGALG_SHA256_WITH_ECDSA);
+
+        // We are all set and now ready to renew the CA
+        // Lets do a name change too
+        final String newSubjectDN = "CN=NewName,o=Test";
+        final String newCAName = "NewName";
+
+        try {
+            iCP = certificateProfileSession.addCertificateProfile(internalAdmin, "TESTRENEWALWITHEC", cpCA);
+            // Update the CA
+            info.setCertificateProfileId(iCP);
+            caSession.editCA(internalAdmin, info);
+ 
+            // Renew the CA with name change
+            caAdminSession.renewCANewSubjectDn(internalAdmin, info.getCAId(), sNextKeyAlias, null, /*CreateLinkCert*/true, newSubjectDN);
+
+            // Let check the CA's new certificate has the ECDSA based signature algorithm
+            X509CAInfo newinfo = (X509CAInfo) caSession.getCAInfo(internalAdmin, newCAName);
+            X509Certificate newcert = (X509Certificate) newinfo.getCertificateChain().iterator().next();
+            String sNewSigAlg = ((X509Certificate) newcert).getSigAlgName();
+            assertTrue("Previous Signing Algorithm was " + sPreviousSigAlg + " and new Signing Algorithm was " + sNewSigAlg  + ". Was expecting it to be ECDSA based.", sNewSigAlg.contains("ECDSA"));
+            
+            // Check the Link certificate was signed using the previous Signing Algorithm
+            byte[] linkCertificateAfterRenewal1Bytes = caAdminSession.getLatestLinkCertificate(newinfo.getCAId());
+            assertTrue("There is no available link certificate after CA renewal with EC key", linkCertificateAfterRenewal1Bytes != null);
+            @SuppressWarnings("deprecation")
+            X509Certificate linkCertificateAfterRenewal = (X509Certificate) com.keyfactor.util.CertTools.getCertfromByteArray(linkCertificateAfterRenewal1Bytes);
+            assertTrue("The Link certificate should be signed by the CA's previous signing algorithm, not "+ linkCertificateAfterRenewal.getSigAlgName(), linkCertificateAfterRenewal.getSigAlgName().equalsIgnoreCase(sPreviousSigAlg));
+
+            // Check the SignatureAlgorithm on the CA's Token is still set correctly
+            assertTrue("The signature algorithm on the CA's token was changed and should not be " + caToken.getSignatureAlgorithm(), caToken.getSignatureAlgorithm().equals(AlgorithmConstants.SIGALG_SHA256_WITH_ECDSA));
+
+            // Check the Signature Algorithm on the CertPolicy is still set correctly
+            assertTrue("The signature algorithm on the CA's certificate profile was changed and should not be " + cpCA.getSignatureAlgorithm(),  cpCA.getSignatureAlgorithm().equals(AlgorithmConstants.SIGALG_SHA256_WITH_ECDSA));
+
+            // Check the Link cert's IssuerDN matches the original CA's SubjectDN 
+            assertTrue("The IssuerDN of the Link certificate does not match the SubjectDN of the original CA certificate.",  linkCertificateAfterRenewal.getIssuerDN().equals(orgcert.getSubjectDN()));
+
+            // Check the Link cert's SubjectDN doesn't matches the original CA's SubjectDN 
+            // Note: There is a Name change occurring
+            assertTrue("The SubjectDN of the Link certificate should not match the SubjectDN of the original CA certificate.", !linkCertificateAfterRenewal.getSubjectDN().equals(orgcert.getSubjectDN()));
+            assertTrue("The SubjectDN of the Link certificate should match the SubjectDN of the renewed CA certificate.",  linkCertificateAfterRenewal.getSubjectDN().equals(newcert.getSubjectDN()));
+        } finally {
+            // Remove the certificate profile we just created.
+            certificateProfileSession.removeCertificateProfile(internalAdmin, "TESTRENEWALWITHEC");
+
+            // Clean up the renewed CA with name change
+            removeTestCA(newCAName);
+            internalCertificateStoreSession.removeCRLs(internalAdmin, newSubjectDN);
+
+            // Ensure the global configuration is reverted.
+            globalConfiguration.setEnableIcaoCANameChange(backupEnableIcaoCANameChangeValue);
+            globalConfigSession.saveConfiguration(internalAdmin, globalConfiguration);
+        }
+        
+       // Test done!
+        log.trace("<testrenewCA_ChangeKeyAlgWithNameChange()");
     }
 
     

--- a/modules/systemtests/src-test/org/ejbca/core/ejb/ca/caadmin/RenewCATest.java
+++ b/modules/systemtests/src-test/org/ejbca/core/ejb/ca/caadmin/RenewCATest.java
@@ -29,6 +29,8 @@ import org.cesecore.certificates.ca.CaSessionRemote;
 import org.cesecore.certificates.ca.X509CAInfo;
 import org.cesecore.certificates.ca.catoken.CAToken;
 import org.cesecore.certificates.certificateprofile.CertificateProfileConstants;
+import org.cesecore.certificates.certificateprofile.CertificateProfileSessionRemote;
+import org.cesecore.keys.token.CryptoTokenManagementSessionRemote;
 import org.cesecore.keys.token.CryptoTokenTestUtils;
 import org.cesecore.mock.authentication.tokens.TestAlwaysAllowLocalAuthenticationToken;
 import org.cesecore.util.EjbRemoteHelper;

--- a/modules/systemtests/src-test/org/ejbca/core/ejb/ca/caadmin/RenewCATest.java
+++ b/modules/systemtests/src-test/org/ejbca/core/ejb/ca/caadmin/RenewCATest.java
@@ -80,12 +80,12 @@ public class RenewCATest extends CaTestCase {
     @Test
     public void test01renewCA() throws Exception {
         log.trace(">test01renewCA()");
-        X509CAInfo info = (X509CAInfo) caSession.getCAInfo(internalAdmin, "TEST");
+        X509CAInfo info = (X509CAInfo) caSession.getCAInfo(internalAdmin, getTestCAName());
         X509Certificate orgcert = (X509Certificate) info.getCertificateChain().iterator().next();
         // Sleep at least for one second so we are not so fast that we create a new cert with the same time
         Thread.sleep(2000);
         caAdminSession.renewCA(internalAdmin, info.getCAId(), false, null, false);
-        X509CAInfo newinfo = (X509CAInfo) caSession.getCAInfo(internalAdmin, "TEST");
+        X509CAInfo newinfo = (X509CAInfo) caSession.getCAInfo(internalAdmin, getTestCAName());
         X509Certificate newcertsamekeys = (X509Certificate) newinfo.getCertificateChain().iterator().next();
         assertTrue(!orgcert.getSerialNumber().equals(newcertsamekeys.getSerialNumber()));
         byte[] orgkey = orgcert.getPublicKey().getEncoded();
@@ -95,7 +95,7 @@ public class RenewCATest extends CaTestCase {
         assertTrue("newcertsamekeys.getNotAfter: " + newcertsamekeys.getNotAfter() + " orgcert.getNotAfter: " + orgcert.getNotAfter(),
                 newcertsamekeys.getNotAfter().after(orgcert.getNotAfter()));
         caAdminSession.renewCA(internalAdmin, info.getCAId(), true, null, false);
-        X509CAInfo newinfo2 = (X509CAInfo) caSession.getCAInfo(internalAdmin, "TEST");
+        X509CAInfo newinfo2 = (X509CAInfo) caSession.getCAInfo(internalAdmin, getTestCAName());
         X509Certificate newcertnewkeys = (X509Certificate) newinfo2.getCertificateChain().iterator().next();
         assertTrue(!orgcert.getSerialNumber().equals(newcertnewkeys.getSerialNumber()));
         byte[] newkey = newcertnewkeys.getPublicKey().getEncoded();
@@ -111,7 +111,7 @@ public class RenewCATest extends CaTestCase {
     public void testrenewCA_ChangeKeyAlg() throws Exception {
         log.trace(">testrenewCA_ChangeKeyAlg()");
         
-        X509CAInfo info = (X509CAInfo) caSession.getCAInfo(internalAdmin, "TEST");
+        X509CAInfo info = (X509CAInfo) caSession.getCAInfo(internalAdmin, getTestCAName());
         X509Certificate orgcert = (X509Certificate) info.getCertificateChain().iterator().next();
         // Sleep at least for one second so we are not so fast that we create a new cert with the same time
         Thread.sleep(2000);
@@ -158,7 +158,7 @@ public class RenewCATest extends CaTestCase {
         }
         
         // Let check the CA's new certificate has the ECDSA based signing algorithm
-        X509CAInfo newinfo = (X509CAInfo) caSession.getCAInfo(internalAdmin, "TEST");
+        X509CAInfo newinfo = (X509CAInfo) caSession.getCAInfo(internalAdmin, getTestCAName());
         X509Certificate newcert = (X509Certificate) newinfo.getCertificateChain().iterator().next();
         String sNewSigAlg = ((X509Certificate)newcert).getSigAlgName();
         assertTrue( "Previous Signing Algorith was "+sPreviousSigAlg+" and new Signing Algorithm was "+sNewSigAlg+". Was expecting it to be ECDSA based.",
@@ -181,7 +181,7 @@ public class RenewCATest extends CaTestCase {
     @Test
     public void testRenewSubCAWithRenewCAWorker() throws Exception {
         log.trace(">testRenewSubCAWithRenewCAWorker()");
-        X509CAInfo info = (X509CAInfo) caSession.getCAInfo(internalAdmin, "TEST");
+        X509CAInfo info = (X509CAInfo) caSession.getCAInfo(internalAdmin, getTestCAName());
         final int cryptoTokenIdSubCa = CryptoTokenTestUtils.createCryptoTokenForCA(null, "foo123".toCharArray(), true, false, "TestSubCaRenew", "1024", "1024", CAToken.SOFTPRIVATESIGNKEYALIAS, CAToken.SOFTPRIVATEDECKEYALIAS);
         final CAToken subCaToken = CaTestUtils.createCaToken(cryptoTokenIdSubCa, AlgorithmConstants.SIGALG_SHA1_WITH_RSA, AlgorithmConstants.SIGALG_SHA1_WITH_RSA, CAToken.SOFTPRIVATESIGNKEYALIAS, CAToken.SOFTPRIVATEDECKEYALIAS);
         try {


### PR DESCRIPTION
It is possible to get EJBCA to renew a CA using a different signing key algorithm (ie., RSA to ECDSA). The steps required are:
1. Create a new EC key on the CA's CryptoToken (assuming a move from RSA to ECDSA)
2. Set the CryptoToken's Signature Algorithm to use ECDSA. This can be done using the Command Line Interface. (Potentially, this step could be handled by an appropriate code change)
3. Set the Certificate Profile to use ECDSA-based Signature Algorithm.
4. Do the CA Renewal

These steps work well, but not if the Link Certificate is required. The Link certificate needs to be signed using the CA's previous signature algorithm, and the changes to the CryptoToken and the Certificate Profile affect the Link certificate generation.

Code changes are required to detect when a CA's key algorithm change is occuring, logs an informational message and then sets up the CA's Token and Certificate Profile to use previous Signature Algorithm just prior to the Link certificate being generated. After the Link certificate is created, the settings are reverted (just in case it affects other downstream processing).

Note that this change will detect when the signature 'digest' is changing (ie., SHA256 to SHA512) even though the key algorithm is not changing. This will mean that the Link certiifcate will be signed by the previous digest algorithm. This is unlikely to ever be a problem, but thought it noteworthy to mention.

A test case has been included in the change.