### PR TITLE
Improve: RA GUI Make New Request page CSS

### DIFF
--- a/modules/ra-gui/resources/css/ra.css
+++ b/modules/ra-gui/resources/css/ra.css
@@ -100,6 +100,24 @@
 	padding: 0;
 }
 
+.internal-frame fieldset > .pure-control-group > label,
+#requestInfoForm\:selectKeyAlgorithmOuterPanel > .internal-frame > .pure-control-group > label {
+    min-width: 22.0em;
+}
+.internal-frame fieldset > .pure-control-group > input[type="text"],
+.internal-frame fieldset > .pure-control-group > input[type="password"],
+.internal-frame fieldset > .pure-control-group > input[type="email"],
+.internal-frame fieldset > .pure-control-group > input[type="url"],
+.internal-frame fieldset > .pure-control-group > input[type="number"],
+.internal-frame fieldset > .pure-control-group > input[type="search"],
+.internal-frame fieldset > .pure-control-group > textarea {
+    min-width: 27.8em;
+}
+.internal-frame fieldset > .pure-control-group > select,
+#requestInfoForm\:selectKeyAlgorithmOuterPanel > .internal-frame > .pure-control-group > select {
+    min-width: 36.7%;
+}
+
 .internal-frame-with-left-margin {
 	margin-left: 5em;
 }
@@ -135,9 +153,29 @@
 	margin: 0.5em 0 0.2em;
 }
 
+.ra-MakeRequest {
+	color: #fff;
+}
+
 .pure-control-group {
 	padding: 0 0.5em;
 	margin: 0 0.25em;
+}
+
+.pure-form-aligned .pure-control-group label {
+    min-width: 17em;
+}
+.pure-form-aligned .pure-control-group input[type="text"],
+.pure-form-aligned .pure-control-group input[type="password"],
+.pure-form-aligned .pure-control-group input[type="email"],
+.pure-form-aligned .pure-control-group input[type="url"],
+.pure-form-aligned .pure-control-group input[type="number"],
+.pure-form-aligned .pure-control-group input[type="search"],
+.pure-form-aligned .pure-control-group textarea {
+    min-width: 25em;
+}
+.pure-form-aligned .pure-control-group select {
+    /* min-width: 27.8em;	/* Too wide for Email address domain list! */
 }
 
 .bigStatus {
@@ -376,4 +414,39 @@ input[type="file"] {
 
 input[type="file"]:focus {
 	outline: none !important;
+}
+
+@media (max-width: 47.99em) {
+
+    .internal-frame fieldset > .pure-control-group > input[type="text"],
+    .internal-frame fieldset > .pure-control-group > input[type="password"],
+    .internal-frame fieldset > .pure-control-group > input[type="email"],
+    .internal-frame fieldset > .pure-control-group > input[type="url"],
+    .internal-frame fieldset > .pure-control-group > input[type="number"],
+    .internal-frame fieldset > .pure-control-group > input[type="search"],
+    .internal-frame fieldset > .pure-control-group > select,
+    .internal-frame fieldset > .pure-control-group > textarea {
+        min-width: 100%;
+    }
+
+    .pure-form-aligned .pure-control-group input[type="text"],
+    .pure-form-aligned .pure-control-group input[type="password"],
+    .pure-form-aligned .pure-control-group input[type="email"],
+    .pure-form-aligned .pure-control-group input[type="url"],
+    .pure-form-aligned .pure-control-group input[type="number"],
+    .pure-form-aligned .pure-control-group input[type="search"],
+    .pure-form-aligned .pure-control-group select,
+    .pure-form-aligned .pure-control-group textarea {
+        min-width: 100%;
+    }
+
+}
+
+@media (min-width: 64.0104em) {
+
+    #requestTemplateForm\:selectRequestTemplateOuterPanel .internal-frame fieldset > .pure-control-group:nth-child(1),
+    #requestTemplateForm\:selectRequestTemplateOuterPanel .internal-frame fieldset > .pure-control-group:nth-child(2) {
+        margin-bottom: -1.7em;
+    }
+
 }

--- a/modules/ra-gui/resources/enrollmakenewrequest.xhtml
+++ b/modules/ra-gui/resources/enrollmakenewrequest.xhtml
@@ -45,7 +45,7 @@
 							<h:panelGroup layout="block" styleClass="pure-control-group"
                                 rendered="#{enrollMakeNewRequestBean.selectEndEntityProfileRendered}">
 								<h:outputLabel for="selectEEPOneMenu" value="#{msg.enroll_certificate_type}"/>
-								<h:selectOneMenu id="selectEEPOneMenu" styleClass="jsAutoFocusLast" style="width: 30%; margin-right: 5%;"
+								<h:selectOneMenu id="selectEEPOneMenu" styleClass="jsAutoFocusLast" style="margin-right: 5%;"
 									value="#{enrollMakeNewRequestBean.selectedEndEntityProfile}"
 									disabled="#{enrollMakeNewRequestBean.availableEndEntityProfileSelectItems.size()==1}">
 									<f:selectItems value="#{enrollMakeNewRequestBean.availableEndEntityProfileSelectItems}"/>
@@ -62,7 +62,7 @@
 							<h:panelGroup layout="block" styleClass="pure-control-group"
                                 rendered="#{enrollMakeNewRequestBean.selectCertificateProfileRendered}">
 								<h:outputLabel for="selectCPOneMenu" value="#{msg.enroll_certificate_subtype}"/>
-								<h:selectOneMenu id="selectCPOneMenu" styleClass="jsAutoFocusLast" style="width: 30%; margin-right: 5%;"
+								<h:selectOneMenu id="selectCPOneMenu" styleClass="jsAutoFocusLast" style="margin-right: 5%;"
 									value="#{enrollMakeNewRequestBean.selectedCertificateProfile}"
 									disabled="#{enrollMakeNewRequestBean.availableCertificateProfileSelectItems.size()==1}">
 									<f:selectItems value="#{enrollMakeNewRequestBean.availableCertificateProfileSelectItems}"/>
@@ -485,7 +485,7 @@
                                         <h:message for="upnRfcEmail2" id="upnRfcEmailMessage2" styleClass="showErrorMessage"/>
                                     </h:panelGroup>
 									<h:panelGroup rendered="#{instance.copyDns || instance.copyUpn}">
-										<h:outputText value="#{msg.subject_alternative_name_USEENTITYCNFIELD}" styleClass="ra-outputText" />
+										<h:outputText value="#{msg.subject_alternative_name_USEENTITYCNFIELD}" styleClass="ra-outputText ra-MakeRequest" />
 									</h:panelGroup>
 								</h:panelGroup>
 							</ui:repeat>
@@ -562,7 +562,7 @@
                                         <h:message for="upnRfcEmail2" id="upnRfcEmailMessage2" styleClass="showErrorMessage"/>
                                     </h:panelGroup>
 									<h:panelGroup rendered="#{instance.copyDns || instance.copyUpn}">
-										<h:outputText value="#{msg.subject_alternative_name_USEENTITYCNFIELD}" styleClass="ra-outputText"/>
+										<h:outputText value="#{msg.subject_alternative_name_USEENTITYCNFIELD}" styleClass="ra-outputText ra-MakeRequest"/>
 									</h:panelGroup>
                             	</h:panelGroup>
                             	</ui:fragment>


### PR DESCRIPTION
Better default CSS style for Make New Request page, in RA GUI.

**Features:**
- use of the full width of the page
- the input fields are wider: better to check input values
- all the main input fields are in center of the page, and vertical aligned
- all the field label are in one, or two lines (note: one line in future contribution)
- like the Pure CSS base, it's still a responsive design
- I only modified the default '`ra.css`' file: so, admins always can customize CSS with the '`w_e_styles.css`' file
- fix the text '_Use Entity CN Field_' in white (it was unreadable in black color)
- tested with Firefox, and Chrome