### PR TITLE
Fix: fix sql syntax error in sql upgrade file for 790_7100

### DIFF
--- a/src/upgrade/650_660/650_660-upgrade-mssql2000.sql
+++ b/src/upgrade/650_660/650_660-upgrade-mssql2000.sql
@@ -9,6 +9,6 @@
 --
 -- subjectDN and subjectAltName columns in UserData has been extended to accommodate longer names
 -- subjectDN from 250 to 400 characters and subjectAltName from 250 to 2000 characters
--- ALTER TABLE UserData MODIFY subjectAltName VARCHAR(2000);
--- ALTER TABLE UserData MODIFY subjectDN VARCHAR(400);
--- ALTER TABLE CertificateData MODIFY subjectDN VARCHAR(400);
+-- ALTER TABLE UserData ALTER COLUMN subjectAltName VARCHAR(2000);
+-- ALTER TABLE UserData ALTER COLUMN subjectDN VARCHAR(400);
+-- ALTER TABLE CertificateData ALTER COLUMN subjectDN VARCHAR(400);

--- a/src/upgrade/790_7100/790_7100-upgrade-mssql2000.sql
+++ b/src/upgrade/790_7100/790_7100-upgrade-mssql2000.sql
@@ -1,5 +1,5 @@
 -- subjectDn column size is increased in ApprovalData table to conform with subjectDn in other tables e.g. UserData
--- ALTER TABLE ApprovalData MODIFY subjectDn VARCHAR(400);
+-- ALTER TABLE ApprovalData ALTER COLUMN subjectDn VARCHAR(400);
 
 -- ALTER TABLE AcmeAuthorizationData ADD identifier VARCHAR(256);
 -- ALTER TABLE AcmeAuthorizationData ADD identifierType VARCHAR(20);


### PR DESCRIPTION
change sql syntax from
ALTER TABLE ApprovalData MODIFY subjectDn VARCHAR(400); for mysql
to
ALTER TABLE ApprovalData ALTER COLUMN subjectDn VARCHAR(400); for mssql

in 790_7100-upgrade-mssql2000.sql

I don't know how to create JUnit test case for this change, please contact me if needed.