### PR TITLE
Fix: RA GUI layout (CSS align, SDA bug, Search improv)

### DIFF
--- a/modules/ra-gui/resources/css/ra.css
+++ b/modules/ra-gui/resources/css/ra.css
@@ -44,7 +44,7 @@
 
 .content-body h2 {
 	margin: 0.2em 0;
-	font-size: 1.3em;
+	font-size: 1.4em;
 	font-weight: 300;
 	color: #1f589f;
 }
@@ -98,24 +98,6 @@
 
 .internal-frame fieldset {
 	padding: 0;
-}
-
-.internal-frame fieldset > .pure-control-group > label,
-#requestInfoForm\:selectKeyAlgorithmOuterPanel > .internal-frame > .pure-control-group > label {
-    min-width: 22.0em;
-}
-.internal-frame fieldset > .pure-control-group > input[type="text"],
-.internal-frame fieldset > .pure-control-group > input[type="password"],
-.internal-frame fieldset > .pure-control-group > input[type="email"],
-.internal-frame fieldset > .pure-control-group > input[type="url"],
-.internal-frame fieldset > .pure-control-group > input[type="number"],
-.internal-frame fieldset > .pure-control-group > input[type="search"],
-.internal-frame fieldset > .pure-control-group > textarea {
-    min-width: 27.8em;
-}
-.internal-frame fieldset > .pure-control-group > select,
-#requestInfoForm\:selectKeyAlgorithmOuterPanel > .internal-frame > .pure-control-group > select {
-    min-width: 36.7%; max-width: 30%;
 }
 
 .internal-frame-with-left-margin {
@@ -176,6 +158,11 @@
 }
 .pure-form-aligned .pure-control-group select {
     /* min-width: 27.8em;	/* Too wide for Email address domain list! */
+}
+.pure-form-aligned #requestTemplateForm\:selectRequestTemplateOuterPanel .pure-control-group select,
+.pure-form-aligned #requestInfoForm\:selectKeyAlgorithmOuterPanel .pure-control-group select,
+.pure-form-aligned #requestInfoForm\:selectTokenOuterPanel .pure-control-group select {
+    min-width: 27.8em;
 }
 
 .bigStatus {
@@ -356,9 +343,20 @@ textarea.row-odd,
 	margin-right: 5px;
 }
 
+.ra-editEndEntity input:nth-of-type(1)[type="text"],
+.ra-editEndEntity input:nth-of-type(1)[type="password"],
+.ra-editEndEntity input:nth-of-type(1)[type="email"],
+.ra-editEndEntity input:nth-of-type(1)[type="url"],
+.ra-editEndEntity input:nth-of-type(1)[type="number"],
+.ra-editEndEntity input:nth-of-type(1)[type="search"],
+.ra-editEndEntity textarea {
+    width: 25em;
+}
+
 .editNameConstraints {
 	width: 50%;
-	margin: 5px;
+	min-width: 25em;
+	margin: 0.5em 0 0.2em 0;
 }
 
 #detailsForm .ra-editEndEntity table {
@@ -371,8 +369,9 @@ textarea.row-odd,
 
 .ra-editEndEntity .remaining-number-of-login-attempts, .ra-editEndEntity .next-to-radio
 	{
-	width: 40px;
+	width: 3em !important;
 	margin-right: 15px;
+	text-align: center;
 }
 
 .edit-ee-update-keytype {
@@ -422,17 +421,6 @@ input[type="file"]:focus {
 
 @media (max-width: 47.99em) {
 
-    .internal-frame fieldset > .pure-control-group > input[type="text"],
-    .internal-frame fieldset > .pure-control-group > input[type="password"],
-    .internal-frame fieldset > .pure-control-group > input[type="email"],
-    .internal-frame fieldset > .pure-control-group > input[type="url"],
-    .internal-frame fieldset > .pure-control-group > input[type="number"],
-    .internal-frame fieldset > .pure-control-group > input[type="search"],
-    .internal-frame fieldset > .pure-control-group > select,
-    .internal-frame fieldset > .pure-control-group > textarea {
-        min-width: 100%;
-    }
-
     .pure-form-aligned .pure-control-group input[type="text"],
     .pure-form-aligned .pure-control-group input[type="password"],
     .pure-form-aligned .pure-control-group input[type="email"],
@@ -442,6 +430,32 @@ input[type="file"]:focus {
     .pure-form-aligned .pure-control-group select,
     .pure-form-aligned .pure-control-group textarea {
         min-width: 100%;
+    }
+    .pure-form-aligned #requestTemplateForm\:selectRequestTemplateOuterPanel .pure-control-group select,
+    .pure-form-aligned #requestInfoForm\:selectKeyAlgorithmOuterPanel .pure-control-group select,
+    .pure-form-aligned #requestInfoForm\:selectTokenOuterPanel .pure-control-group select {
+        min-width: 100%;
+    }
+
+    .ra-editEndEntity input[type="text"],
+    .ra-editEndEntity input[type="email"],
+    .ra-editEndEntity input[type="url"],
+    .ra-editEndEntity input[type="number"],
+    .ra-editEndEntity input[type="search"],
+    .ra-editEndEntity textarea {
+        width: 90%;
+    }
+    .ra-editEndEntity input[type="password"] {
+        width: 180%;
+    }
+    .ra-editEndEntity select {
+        width: 95% !important;
+    }
+    .editNameConstraints {
+        width: 95%;
+    }
+    .ra-editEndEntity .remaining-number-of-login-attempts, .ra-editEndEntity .next-to-radio {
+        width: 3em !important;
     }
 
 }

--- a/modules/ra-gui/resources/css/ra.css
+++ b/modules/ra-gui/resources/css/ra.css
@@ -459,12 +459,3 @@ input[type="file"]:focus {
     }
 
 }
-
-@media (min-width: 64.0104em) {
-
-    #requestTemplateForm\:selectRequestTemplateOuterPanel .internal-frame fieldset > .pure-control-group:nth-child(1),
-    #requestTemplateForm\:selectRequestTemplateOuterPanel .internal-frame fieldset > .pure-control-group:nth-child(2) {
-        margin-bottom: -1.7em;
-    }
-
-}

--- a/modules/ra-gui/resources/css/w_e_style.css
+++ b/modules/ra-gui/resources/css/w_e_style.css
@@ -88,7 +88,6 @@ h1, h2, h3, h4, p, span {
 
 .content-body h3 {
     color: #fff;
-    font-weight: lighter;
     width: 90%;
     margin: 2% 0 2% 1.5%;
 }
@@ -629,6 +628,7 @@ textarea#enrollWithRequestIdForm\:certificateRequest {
     font-weight: bold;
 }
 
+#detailsForm > span.pure-u-1:nth-of-type(2) > .subjects > span > label,
 #detailsForm > span.pure-u-1:nth-of-type(2) > .subjects > label {
     margin-left: 2.5% !important;
     font-weight: bold;
@@ -1757,6 +1757,7 @@ table#contentForm\:searchCertTable > tbody > tr > td > input:hover, #contentForm
         margin: 0;
     }
 
+    #detailsForm .subjects > span > label:not(.pure-u-lg-1),
     #detailsForm > span.pure-u-1:nth-of-type(2) > label:not(.pure-u-lg-1), #detailsForm .subjects > label:not(.pure-u-lg-1) {
         width: 30.8%;
     }
@@ -1821,7 +1822,7 @@ table#contentForm\:searchCertTable > tbody > tr > td > input:hover, #contentForm
     #requestInfoForm\:generateP12,
     #requestInfoForm\:generateBcfks,
     #requestInfoForm\:generateJks {
-        width: auto;
+        width: auto !important;
     }
 
     .infoMessage {
@@ -2172,27 +2173,25 @@ table#contentForm\:searchCertTable > tbody > tr > td > input:hover, #contentForm
         width: 83%;
     }
 
+    #contentForm\:modifiedAfter,
+    #contentForm\:modifiedBefore,
     #contentForm\:issuedAfter,
     #contentForm\:issuedBefore,
     #contentForm\:expiresAfter,
     #contentForm\:expiresBefore,
     #contentForm\:revokedAfter,
     #contentForm\:revokedBefore {
-        width: 119%;
+        width: 116%;
+        min-width: 116%;
         font-size: 95%;
     }
 
     #contentForm\:more > span.pure-g > div.pure-u-1:nth-of-type(2) {
-        width: 24%;
-    }
-
-    #contentForm\:more > span.pure-g > div.pure-u-1:nth-of-type(2) > .pure-control-group #contentForm\:modifiedAfter,
-    #contentForm\:more > span.pure-g > div.pure-u-1:nth-of-type(2) > .pure-control-group #contentForm\:modifiedBefore {
-        width: 152%;
+        width: 25%;
     }
 
     #contentForm\:endEntititesMoreInputs {
-        width: 20% !important;
+        width: 25% !important;
     }
 
     #detailsForm > span.pure-u-1:nth-of-type(2) > label {
@@ -2437,6 +2436,13 @@ table#contentForm\:searchCertTable > tbody > tr > td > input:hover, #contentForm
     .parentCriteriaDropdown,
     .parentCriteriaCheckbox {
         width: 22%;
+    }
+
+    #contentForm\:parentCriteriaEepId select,
+    #contentForm\:parentCriteriaCpId select,
+    #contentForm\:parentCriteriaCaId select,
+    #contentForm\:parentCriteriaStatus select {
+        width: 100% !important;
     }
 
     /*

--- a/modules/ra-gui/resources/enrollmakenewrequest.xhtml
+++ b/modules/ra-gui/resources/enrollmakenewrequest.xhtml
@@ -41,6 +41,7 @@
 						<h:outputText value="#{msg.enroll_select_request_template}" />
 					</h2>
 					<h:panelGroup layout="block" styleClass="internal-frame">
+						<h:panelGroup layout="block" styleClass="internal-frame-with-left-margin">
 						<fieldset>
 							<h:panelGroup layout="block" styleClass="pure-control-group"
                                 rendered="#{enrollMakeNewRequestBean.selectEndEntityProfileRendered}">
@@ -106,6 +107,7 @@
                                 </h:panelGroup>
 							</h:panelGroup>
 						</fieldset>
+						</h:panelGroup>
 
                         <fieldset>
                             <h:commandButton id="applyRequestTemplateButton"
@@ -133,11 +135,11 @@
 						<h:outputText value="#{msg.enroll_upload_csr}" />
 					</h2>
 					<h:panelGroup layout="block" styleClass="internal-frame" rendered="#{!enrollMakeNewRequestBean.uploadCsrDoneRendered}">
+						<h:panelGroup layout="block" styleClass="pure-control-group">
 						<h:inputFile id="certificateUploadInput" 
 							value="#{enrollMakeNewRequestBean.uploadFile}" size="20" 
 							onchange="document.getElementById('keyPairForm:updateCsrInfoFields').click();"/>
-						
-						<br/>
+						</h:panelGroup>
 						
 						<h:commandButton id="updateCsrInfoFields" value="invisible import button" style="display:none"
 							action="#{enrollMakeNewRequestBean.actionUpdateCsrInfoFields}"/>
@@ -224,12 +226,11 @@
 						<h:outputText value="#{msg.enroll_upload_ssh_public_key}" />
 					</h2>
 					<h:panelGroup layout="block" styleClass="internal-frame">
+						<h:panelGroup layout="block" styleClass="pure-control-group">
 						<h:inputFile id="sshPubKeyUploadInput" 
 							value="#{enrollMakeNewRequestBean.uploadFile}" size="20" 
 							onchange="document.getElementById('sshPubKeyForm:updateSshKeyInfoFields').click();"/>
-						
-						<br/>
-						<br/>
+						</h:panelGroup>
 						
 						<h:inputTextarea id="sshPubKeyRequest" 
 							styleClass="fineprintMono jsAutoFocusLast" style="line-height: 100%;"
@@ -265,6 +266,7 @@
 						<h:outputText value="#{msg.enroll_select_key_algorithm}" />
 					</h2>
 					<h:panelGroup layout="block" styleClass="internal-frame">
+						<h:panelGroup layout="block" styleClass="internal-frame-with-left-margin">
 						<h:panelGroup layout="block" styleClass="pure-control-group">
 							<h:outputLabel for="selectAlgorithmOneMenu" value="#{msg.enroll_key_algorithm}" />
 							<h:selectOneMenu id="selectAlgorithmOneMenu" styleClass="jsAutoFocusLast"
@@ -273,6 +275,7 @@
 								<f:selectItems value="#{enrollMakeNewRequestBean.availableAlgorithmSelectItems}" />
 								<f:ajax event="change" execute="@this" render=":globalMessages :requestInfoForm:requestPreviewOuterPanel @form"/>
 							</h:selectOneMenu>
+						</h:panelGroup>
 						</h:panelGroup>
 						<fieldset>
 							<h:commandButton id="applyAlgorithmButton"
@@ -289,6 +292,7 @@
 						<h:outputText value="#{msg.enroll_select_token_type}"/>
 					</h2>
 					<h:panelGroup layout="block" styleClass="internal-frame">
+						<h:panelGroup layout="block" styleClass="internal-frame-with-left-margin">
 						<h:panelGroup layout="block" styleClass="pure-control-group">
 							<h:outputLabel for="selectTokenOneMenu" value="#{msg.enroll_token}" />
 							<h:selectOneMenu id="selectTokenOneMenu" styleClass="jsAutoFocusLast"
@@ -296,6 +300,7 @@
 									<f:selectItems value="#{enrollMakeNewRequestBean.availableTokenTypesSelectItems}" />
 									<f:ajax event="change" execute="@this" render=":globalMessages :requestInfoForm:requestPreviewOuterPanel @form"/>
 							</h:selectOneMenu>
+						</h:panelGroup>
 						</h:panelGroup>
 					</h:panelGroup>
 				</h:panelGroup>
@@ -590,12 +595,14 @@
 													enrollMakeNewRequestBean.isNameConstraintExcludedRendered()}">
 							
 							<h3>
-								<h:outputText value="#{msg.enroll_name_constraint_attributes}" rendered="#{enrollMakeNewRequestBean.isNameConstraintPermittedRendered()}"/>
+								<h:outputText value="#{msg.enroll_name_constraint_attributes}" rendered="#{enrollMakeNewRequestBean.isNameConstraintPermittedRendered() or 
+																											enrollMakeNewRequestBean.isNameConstraintExcludedRendered()}"/>
 							</h3>
-							<h:panelGroup layout="block" styleClass="pure-control-group" 
+
+							<h:panelGroup layout="block" styleClass="internal-frame-with-left-margin" 
 										rendered="#{enrollMakeNewRequestBean.isNameConstraintPermittedRendered()}">
 							
-							<h:panelGroup rendered="#{enrollMakeNewRequestBean.isNameConstraintPermittedRendered()}" >
+							<h:panelGroup layout="block" styleClass="pure-control-group">
 									<h:outputLabel for="nameConstraintPermitted"
 										value="#{msg.enroll_name_constraint_permitted}"
 										rendered="#{enrollMakeNewRequestBean.isNameConstraintPermittedRendered() and 
@@ -604,7 +611,7 @@
 										value="#{msg.enroll_name_constraint_permitted} *"
 										rendered="#{enrollMakeNewRequestBean.isNameConstraintPermittedRendered() and 
 														enrollMakeNewRequestBean.isNameConstraintPermittedRequired()}" />
-									<h:inputTextarea id="nameConstraintPermitted" rows="4" cols="38"
+									<h:inputTextarea id="nameConstraintPermitted" rows="4" cols="35"
 											value="#{enrollMakeNewRequestBean.nameConstraintPermitted}"
                                         rendered="#{enrollMakeNewRequestBean.isNameConstraintPermittedRendered()}" 
                                         required="#{enrollMakeNewRequestBean.isNameConstraintPermittedRequired()}"
@@ -615,10 +622,10 @@
                             
                             </h:panelGroup>
                             
-                            <h:panelGroup layout="block" styleClass="pure-control-group" 
+                            <h:panelGroup layout="block" styleClass="internal-frame-with-left-margin" 
 										rendered="#{enrollMakeNewRequestBean.isNameConstraintExcludedRendered()}">
                             
-                            <h:panelGroup rendered="#{enrollMakeNewRequestBean.isNameConstraintExcludedRendered()}" >
+                            <h:panelGroup layout="block" styleClass="pure-control-group">
 									<h:outputLabel for="nameConstraintExcluded"
 										value="#{msg.enroll_name_constraint_excluded}"
 										rendered="#{enrollMakeNewRequestBean.isNameConstraintExcludedRendered() and 
@@ -627,7 +634,7 @@
 										value="#{msg.enroll_name_constraint_excluded} *"
 										rendered="#{enrollMakeNewRequestBean.isNameConstraintExcludedRendered() and 
 														enrollMakeNewRequestBean.isNameConstraintExcludedRequired()}" />
-									<h:inputTextarea id="nameConstraintExcluded" rows="4" cols="38"
+									<h:inputTextarea id="nameConstraintExcluded" rows="4" cols="35"
 											value="#{enrollMakeNewRequestBean.nameConstraintExcluded}"
                                         rendered="#{enrollMakeNewRequestBean.isNameConstraintExcludedRendered()}" 
                                         required="#{enrollMakeNewRequestBean.isNameConstraintExcludedRequired()}"
@@ -637,6 +644,7 @@
                             </h:panelGroup>
                             
                             </h:panelGroup>
+
                        	</h:panelGroup>
 							
 						<h:panelGroup id="subjectDirectoryAttributeSection" layout="block" styleClass="internal-frame" rendered="#{enrollMakeNewRequestBean.subjectDirectoryAttributesRendered}">
@@ -734,6 +742,7 @@
 							<h3>
 								<h:outputText value="#{msg.enroll_other_cert_data}" />
 							</h3>
+							<h:panelGroup layout="block" styleClass="internal-frame-with-left-margin">
 							<h:panelGroup layout="block" styleClass="pure-control-group" rendered="#{enrollMakeNewRequestBean.renderCertExtensionDataField}">
 								<h:outputLabel for="certExtensionDataField" value="#{msg.enroll_cert_extension_data}"/>
 								<h:inputTextarea id="certExtensionDataField" value="#{enrollMakeNewRequestBean.extensionData}">
@@ -798,17 +807,20 @@
 									<f:selectItems value="#{enrollMakeNewRequestBean.availableRevocationReasons}"/>
 								</h:selectOneMenu>
 							</h:panelGroup>
+							</h:panelGroup>
 						</h:panelGroup>
 						<h:panelGroup id="otherDataSection" layout="block" styleClass="internal-frame" rendered="#{enrollMakeNewRequestBean.renderOtherData}">
 							<h3>
 								<h:outputText value="#{msg.enroll_other_data}" />
 							</h3>
+							<h:panelGroup layout="block" styleClass="internal-frame-with-left-margin">
 							<h:panelGroup layout="block" styleClass="pure-control-group" rendered="#{enrollMakeNewRequestBean.useKeyRecoverable}">
 								<h:outputLabel for="keyRecoveryCheckbox" value="#{msg.component_eedetails_field_keyrecoverable}"/>
 								<h:selectBooleanCheckbox id="keyRecoveryCheckbox" value="#{enrollMakeNewRequestBean.keyRecoverableUse}" 
 										rendered="#{enrollMakeNewRequestBean.useKeyRecoverable}" disabled="#{enrollMakeNewRequestBean.keyRecoveryRequired}">
                             	    <f:ajax execute="@this" render=":requestInfoForm:requestPreviewOuterPanel" />
                             	</h:selectBooleanCheckbox>
+						    </h:panelGroup>
 						    </h:panelGroup>
 						</h:panelGroup>
                         <fieldset>
@@ -828,6 +840,7 @@
 						<h:outputText value="#{msg.enroll_provide_external_account}" />
 					</h2>
 					<h:panelGroup layout="block" styleClass="internal-frame">
+						<h:panelGroup layout="block" styleClass="internal-frame-with-left-margin">
 						<h:panelGroup layout="block" styleClass="pure-control-group" id="accountBindingIdGroup">
 							<h:outputLabel for="accountBindingId" value="#{msg.enroll_EAB} *" />
 							<h:inputText id="accountBindingId" value="#{enrollMakeNewRequestBean.accountBindingId}" 
@@ -847,6 +860,7 @@
 								</h:selectOneMenu>
 							</h:panelGroup>
 							<h:message for="accountBindingId" id="accountBindingIdMessage" styleClass="validationErrorMessage showErrorMessage"/>
+						</h:panelGroup>
 						</h:panelGroup>
 					</h:panelGroup>
 				</h:panelGroup>
@@ -976,12 +990,14 @@
 						<h:outputText value="#{msg.enroll_other_data}" />
 					</h2>
 					<h:panelGroup layout="block" styleClass="internal-frame">
+						<h:panelGroup layout="block" styleClass="internal-frame-with-left-margin">
 						<h:panelGroup layout="block" styleClass="pure-control-group" id="otherDataGroup">
 							<h:outputLabel for="sendNotification" value="#{msg.enroll_notification}" />
 							<h:selectBooleanCheckbox id="sendNotification" disabled="#{enrollMakeNewRequestBean.sendNotificationDisabled}"
 													 value="#{enrollMakeNewRequestBean.sendNotification}" >
 								<f:ajax event="change" render="emailBlock"></f:ajax>
 							</h:selectBooleanCheckbox>
+						</h:panelGroup>
 						</h:panelGroup>
 					</h:panelGroup>
 				</h:panelGroup>
@@ -991,6 +1007,7 @@
 						<h:outputText value="#{msg.enroll_provide_user_credentials}" />
 					</h2>
 					<h:panelGroup layout="block" styleClass="internal-frame">
+						<h:panelGroup layout="block" styleClass="internal-frame-with-left-margin">
 						<fieldset>
 							<h:panelGroup layout="block" styleClass="pure-control-group"
 								rendered="#{enrollMakeNewRequestBean.usernameRendered}">
@@ -1041,6 +1058,7 @@
 								<h:message for="emailField" id="emailFieldMessage" styleClass="validationErrorMessage showErrorMessage"/>
 							</h:panelGroup>
 						</fieldset>
+						</h:panelGroup>
 						<h:inputHidden id="userCredentialsMessageInput" binding="#{enrollMakeNewRequestBean.userCredentialsMessagesComponent}"/>
 						<h:message for="userCredentialsMessageInput" id="userCredentialsMessage" errorClass="showErrorMessage"/>
 					</h:panelGroup>

--- a/modules/ra-gui/resources/enrollmakenewrequest.xhtml
+++ b/modules/ra-gui/resources/enrollmakenewrequest.xhtml
@@ -57,6 +57,7 @@
 								<h:outputText rendered="#{empty enrollMakeNewRequestBean.availableEndEntityProfileSelectItems}"
 									value="#{msg.enroll_no_available_certificate_types}" />
 								<h:outputText id="endEntityProfileDescription"
+									rendered="#{!empty enrollMakeNewRequestBean.endEntityProfile.description}"
 								    styleClass="pure-u-lg-1-3" value="#{enrollMakeNewRequestBean.endEntityProfile.description}"/>
 							</h:panelGroup>
 
@@ -74,6 +75,7 @@
                                 <h:outputText rendered="#{empty enrollMakeNewRequestBean.availableCertificateProfileSelectItems}"
                                     value="#{msg.enroll_no_available_certificate_subtypes}" />
                                 <h:outputText id="certificateProfileDescription"
+									rendered="#{!empty enrollMakeNewRequestBean.certificateProfile.description}"
                                     styleClass="pure-u-lg-1-3" value="#{enrollMakeNewRequestBean.certificateProfile.description}"/>
 							</h:panelGroup>
 

--- a/modules/ra-gui/resources/enrollmakenewrequest.xhtml
+++ b/modules/ra-gui/resources/enrollmakenewrequest.xhtml
@@ -312,7 +312,7 @@
                         <h:outputText value="#{msg.enroll_provide_request_info}" />
                     </h2>
 					<h:panelGroup layout="block" styleClass="internal-frame" rendered="#{enrollMakeNewRequestBean.requestInfoRendered}">
-						<h:panelGroup id="subjectDNSection" layout="block">
+						<h:panelGroup id="subjectDNSection" layout="block" styleClass="internal-frame">
 							<h3>
 								<h:outputText value="#{msg.enroll_required_subject_dn_attributes}" rendered="#{enrollMakeNewRequestBean.subjectDn.requiredFieldInstances.size() gt 0}"/>
 							</h3>
@@ -590,7 +590,7 @@
 							</fieldset>
 						</h:panelGroup>
 						
-						<h:panelGroup id="nameConstraintSection" layout="block" styleClass="pure-control-group" 
+						<h:panelGroup id="nameConstraintSection" layout="block" styleClass="internal-frame" 
 									rendered="#{enrollMakeNewRequestBean.isNameConstraintPermittedRendered() or 
 													enrollMakeNewRequestBean.isNameConstraintExcludedRendered()}">
 							
@@ -872,6 +872,7 @@
 					
 					<h:panelGroup layout="block" styleClass="internal-frame" id="sshCertificateDataGroup">
 						
+						<h:panelGroup layout="block" styleClass="internal-frame-with-left-margin">
 						<h:panelGroup layout="block" styleClass="pure-control-group">
 							<h:outputLabel for="sshKeyId" value="#{msg.enroll_ssh_key_id} *" />
 							<h:inputText id="sshKeyId" value="#{enrollMakeNewRequestBean.sshKeyId}" 
@@ -888,12 +889,13 @@
 								autocomplete="off">
 							</h:inputText>
 						</h:panelGroup>
+						</h:panelGroup>
 						
-						<h:panelGroup id="sshPrincipalsSection" layout="block">
+						<h:panelGroup id="sshPrincipalsSection" layout="block" styleClass="internal-frame" rendered="#{enrollMakeNewRequestBean.sshPrincipals.size() gt 0}">
 						    <h3>
-						        <h:outputText value="#{msg.enroll_ssh_principals}" rendered="#{enrollMakeNewRequestBean.sshPrincipals.size() gt 0}"/>
+						        <h:outputText value="#{msg.enroll_ssh_principals}" />
 						    </h3>
-						    <h:panelGroup layout="block" styleClass="internal-frame-with-left-margin"  rendered="#{enrollMakeNewRequestBean.sshPrincipals.size() gt 0}">
+						    <h:panelGroup layout="block" styleClass="internal-frame-with-left-margin">
 						        <ui:repeat id="sshPrincipal"
 						            value="#{enrollMakeNewRequestBean.sshPrincipals}"
 						            var="instance"
@@ -924,6 +926,8 @@
 						        </ui:repeat>
 						    </h:panelGroup>
 						</h:panelGroup>
+						
+						<h:panelGroup layout="block" styleClass="internal-frame-with-left-margin">
 						
 						<h:panelGroup layout="block" styleClass="pure-control-group">
 							<h:outputLabel for="criticalOptionsSourceAddress" value="#{msg.enroll_ssh_critical_source_address}" 
@@ -980,6 +984,9 @@
 										value="#{enrollMakeNewRequestBean.sshAdditionalExtensions}">
 	                                 </h:inputTextarea>
 	                    </h:panelGroup> -->
+						
+						</h:panelGroup>
+						
 					</h:panelGroup>
 					
 				</h:panelGroup>
@@ -1092,10 +1099,12 @@
 						</h:commandButton>
 						<h:panelGroup 
 						    id="editValidityPanel"
-						    styleClass="pure-control-group">
+						    layout="block" styleClass="internal-frame">
 						    <h3>
                                 <h:outputText value="#{msg.enroll_custom_values}" rendered="#{enrollMakeNewRequestBean.setCustomValidity}" />
                             </h3>
+							<h:panelGroup layout="block" styleClass="internal-frame-with-left-margin">
+							<h:panelGroup layout="block" styleClass="pure-control-group">
 						    <h:outputLabel 
 						        for="validityField" 
 						        value="#{msg.enroll_set_validity}"
@@ -1109,12 +1118,15 @@
 						        value="#{enrollMakeNewRequestBean.validity}">
 						        <f:ajax event="keyup" render=":requestInfoForm:enrollButtons validityFieldHelpText" execute="@this" /> 
 						    </h:inputText>
+							<br />
 						    <h:outputText 
 						        id="validityFieldHelpText" 
 						        for="validityField"
-						        styleClass="showErrorMessage"
+						        styleClass="ra-outputText ra-MakeRequest"
 						        rendered="#{enrollMakeNewRequestBean.setCustomValidity}"
 						        value="#{enrollMakeNewRequestBean.validityHelpMessage}" />
+							</h:panelGroup>
+							</h:panelGroup>
 						</h:panelGroup>
 						
 						<h:panelGroup 

--- a/modules/ra-gui/resources/resources/component/eedetails.xhtml
+++ b/modules/ra-gui/resources/resources/component/eedetails.xhtml
@@ -762,7 +762,8 @@
                                styleClass="pure-u-lg-1-3 row-even"
                                rendered="#{cc.attrs.editMode and not cc.attrs.approvalRequestMode and cc.attrs.raEndEntityDetails.sshTypeEndEntity and cc.attrs.raEndEntityDetails.sshForceCommandRequired}"
                                value="#{msg.component_eedetails_header_ssh_forcecommand} *"/>
-                <h:panelGroup styleClass="pure-u-lg-2-3 ra-outputText row-even ra-editEndEntity">
+                <h:panelGroup styleClass="pure-u-lg-2-3 ra-outputText row-even ra-editEndEntity"
+                              rendered="#{cc.attrs.editMode and not cc.attrs.approvalRequestMode and cc.attrs.raEndEntityDetails.sshTypeEndEntity}">
                     <h:inputText id="forcecommandinput"
                                  value="#{cc.attrs.raEndEntityBean.sshForceCommand}"
                                  rendered="#{cc.attrs.editMode and not cc.attrs.approvalRequestMode and cc.attrs.raEndEntityDetails.sshTypeEndEntity and cc.attrs.raEndEntityDetails.sshForceCommandModifiable}"
@@ -781,7 +782,8 @@
                                styleClass="pure-u-lg-1-3 row-even"
                                rendered="#{cc.attrs.editMode and not cc.attrs.approvalRequestMode and cc.attrs.raEndEntityDetails.sshTypeEndEntity and cc.attrs.raEndEntityDetails.sshSourceAddressRequired}"
                                value="#{msg.component_eedetails_header_ssh_sourceaddress} *"/>
-                <h:panelGroup styleClass="pure-u-lg-2-3 ra-outputText row-even ra-editEndEntity">
+                <h:panelGroup styleClass="pure-u-lg-2-3 ra-outputText row-even ra-editEndEntity"
+                              rendered="#{cc.attrs.editMode and not cc.attrs.approvalRequestMode and cc.attrs.raEndEntityDetails.sshTypeEndEntity}">
                     <h:inputText id="sourceaddressinput"
                                  value="#{cc.attrs.raEndEntityBean.sshSourceAddress}"
                                  rendered="#{cc.attrs.editMode and not cc.attrs.approvalRequestMode and cc.attrs.raEndEntityDetails.sshTypeEndEntity and cc.attrs.raEndEntityDetails.sshSourceAddressModifiable}"
@@ -799,7 +801,8 @@
                                styleClass="pure-u-lg-1-3 row-even"
                                rendered="#{cc.attrs.editMode and not cc.attrs.approvalRequestMode and cc.attrs.raEndEntityDetails.sshTypeEndEntity and cc.attrs.raEndEntityDetails.sshVerifyRequiredRequired}"
                                value="#{msg.component_eedetails_header_ssh_verifyrequired} *"/>
-                <h:panelGroup styleClass="pure-u-lg-2-3 ra-outputText row-even ra-editEndEntity">
+                <h:panelGroup styleClass="pure-u-lg-2-3 ra-outputText row-even ra-editEndEntity"
+                              rendered="#{cc.attrs.editMode and not cc.attrs.approvalRequestMode and cc.attrs.raEndEntityDetails.sshTypeEndEntity}">
                     <h:selectOneMenu id="verifyrequiredinput"
                                      value="#{cc.attrs.raEndEntityBean.sshVerifyRequired}"
                                      rendered="#{cc.attrs.editMode and not cc.attrs.approvalRequestMode and cc.attrs.raEndEntityDetails.sshTypeEndEntity and cc.attrs.raEndEntityDetails.sshVerifyRequiredModifiable}"


### PR DESCRIPTION
OLD REF: PR #551

**Changes > Make New Request (CSS align):**
- CSS horizontal align for 'Make New Request' page (like PR #512): for Token, Name Constraint Attributes, Other Certificate Data, and Other Data
- Bug: when only "Name Constraints, Excluded" is checked without "Name Constraints, Permitted", the title "Name Constraint Attributes" is not displayed
- Better CSS usage: modify HTML source (with adding style, and div) is better than modify CSS style. So I revert a part of my own CSS contribution (PR #512)
- now the CSS is more clear, with less default override, and more readability. So, now it's easier to override '`ra.css`'
- H3 in bold is really better, and more readable. I just removed the override from the CSS '`w_e_style.css`' (and keep the default bold feature from '`ra.css`')
- when I had added the tags '`<h:panelGroup>...<h:panelGroup/>`', I didn't indent the content for better review of the code
**QA:** don't hesitate to test with all Key-pair generation types (By the CA, Provided by user, and Postpone).

**Changes > View/Edit End Entity (SDA bug):**
- in View End Entity: Subject Directory Attributes (SDA) display is broken because the previous display (_i.e._ SSH options) is bugged
- in Edit End Entity: Subject Directory Attributes (SDA) display is broken because the CSS rules doesn't match, because there is an additional '`span`' tag

**Changes > Edit End Entity (Select list fix, CSS align):**
- in Edit End Entity: all Select lists have a fixed width which is too narrow (width forced to 'auto' is better for readability)
- enlarge all text inputs (like PR #512)
- align textarea inputs

**Changes > Search for Certificates/End Entities (improvement):**
- fix some regressions from "Edit End Entity" (Select lists)
- in Search for Certificates: the display of date options are now better
- in Search for End Entities: the display of date options are now better