### PR TITLE
L10n: Admin GUI language fix (ACME)

### DIFF
--- a/modules/admin-gui/resources/languages/languagefile.en.properties
+++ b/modules/admin-gui/resources/languages/languagefile.en.properties
@@ -3781,7 +3781,7 @@ ACME_DNSSEC_TRUST_ANCHOR_HELP           = Trust anchor to use for DNSSEC.
 
 ACME_DEFAULT_CONFIG                     = Default ACME Configuration
 
-ACME_REPLAY_NONCE_VALIDITY              = Replay-Nonce Validity Number
+ACME_REPLAY_NONCE_VALIDITY              = Replay-Nonce Validity (ms)
 
 ACME_ORDER_VALIDITY                     = Order Validity
 
@@ -3795,11 +3795,11 @@ ACME_AUTHORIZED_REDIRECT_PORTS          = Authorized Redirect Ports
 
 ACME_AUTHORIZED_REDIRECT_PORTS_HELP     = Authorized redirect ports on the client for the http-01 challenge validation. Default is 22,25,80,443.
 
-ACME_APPROVAL_NEW_ACCOUNT               = Require approval for account registration
+ACME_APPROVAL_NEW_ACCOUNT               = Approval for account registration
 
 ACME_APPROVAL_NEW_ACCOUNT_HELP          = Account registration requires the approval of one or more administrators. Not compatible to most ACME clients!
 
-ACME_APPROVAL_KEY_CHANGE                = Require approval for account key change
+ACME_APPROVAL_KEY_CHANGE                = Approval for account key change
 
 ACME_APPROVAL_KEY_CHANGE_HELP           = Account key change requires the approval of one or more administrators. Not compatible to most ACME clients!
 

--- a/modules/admin-gui/resources/languages/languagefile.fr.properties
+++ b/modules/admin-gui/resources/languages/languagefile.fr.properties
@@ -3684,7 +3684,7 @@ ACME_TERMS_CHANGE_URL_HELP              = Adresse URL pointant vers des instruct
 
 ACME_TERMS_CHANGE_URL_REQUIRED          = Veuillez saisir l’URL pour les Modifications des Conditions d’utilisation.
 
-ACME_TERMS_APPROVAL                     = Requérir une approbation cliente pour les changements des Conditions d’utilisation
+ACME_TERMS_APPROVAL                     = Requérir une approbation cliente pour tout changement des Conditions d’utilisation
 
 ACME_TERMS_APPROVAL_HELP                = Requiert l’approbation du client pour les modifications des conditions d’utilisation.
 
@@ -3710,7 +3710,7 @@ ACME_DNSSEC_TRUST_ANCHOR_HELP           = Ancre de confiance à utiliser pour DN
 
 ACME_DEFAULT_CONFIG                     = Configuration ACME par défaut
 
-ACME_REPLAY_NONCE_VALIDITY              = Nombre de validité du champ Replay-Nonce
+ACME_REPLAY_NONCE_VALIDITY              = Validité du champ Replay-Nonce (ms)
 
 ACME_ORDER_VALIDITY                     = Validité de la demande
 
@@ -3724,11 +3724,11 @@ ACME_AUTHORIZED_REDIRECT_PORTS          = Ports de redirection autorisés
 
 ACME_AUTHORIZED_REDIRECT_PORTS_HELP     = Ports de redirection autorisés côté client pour la validation du challenge HTTP-01. Par défaut : 22,25,80,443
 
-ACME_APPROVAL_NEW_ACCOUNT               = Requérir une approbation pour l’enregistrement de comptes
+ACME_APPROVAL_NEW_ACCOUNT               = Approbation pour l’enregistrement de comptes
 
 ACME_APPROVAL_NEW_ACCOUNT_HELP          = L’enregistrement de comptes requiert l’approbation d’un ou plusieurs administrateurs. Non compatible avec la plupart des clients ACME !
 
-ACME_APPROVAL_KEY_CHANGE                = Requérir une approbation pour le changement de clé de comptes
+ACME_APPROVAL_KEY_CHANGE                = Approbation pour le changement de clés de comptes
 
 ACME_APPROVAL_KEY_CHANGE_HELP           = Le changement de clé de comptes requiert l’approbation d’un ou plusieurs administrateurs. Non compatible avec la plupart des clients ACME !
 


### PR DESCRIPTION
Fix, and improve some language messages for ACME, in English, and in French languages.

Remarks:
- Unity "ms" is better than the word "Number"
- "Approval" is better than "Require approval" because the field is a drop down list of Approval profiles (not a checkbox)
