### PR TITLE
Fix help text for "removeadmin" command of CLI

### DIFF
--- a/modules/ejbca-ejb-cli/src/org/ejbca/ui/cli/roles/RemoveAdminCommand.java
+++ b/modules/ejbca-ejb-cli/src/org/ejbca/ui/cli/roles/RemoveAdminCommand.java
@@ -51,17 +51,17 @@ public class RemoveAdminCommand extends BaseRolesCommand {
 
     {
         registerParameter(new Parameter(ROLE_NAME_KEY, "Role Name", MandatoryMode.MANDATORY, StandaloneMode.ALLOW, ParameterMode.ARGUMENT,
-                "Role to remove rule from"));
+                "Role to remove admin from"));
         registerParameter(new Parameter(CA_NAME_KEY, "CA Name", MandatoryMode.MANDATORY, StandaloneMode.ALLOW, ParameterMode.ARGUMENT,
                 "Name of the issuing CA"));
         registerParameter(new Parameter(MATCH_WITH_KEY, "Value", MandatoryMode.MANDATORY, StandaloneMode.ALLOW, ParameterMode.ARGUMENT,
-                "The MatchWith Value"));
+                "The MatchWith value"));
         registerParameter(new Parameter(MATCH_TYPE_KEY, "Type", MandatoryMode.OPTIONAL, StandaloneMode.ALLOW, ParameterMode.ARGUMENT,
                 "(Deprected) Match operator type. Kept to prevent legacy scripts from breaking. Currently implied by " + MATCH_WITH_KEY +" switch."));
         registerParameter(new Parameter(MATCH_VALUE_KEY, "Value", MandatoryMode.MANDATORY, StandaloneMode.ALLOW, ParameterMode.ARGUMENT,
-                "The value to match against."));
+                "The value to match against"));
         registerParameter(new Parameter(ROLE_NAMESPACE_KEY, "Role Namespace", MandatoryMode.OPTIONAL, StandaloneMode.FORBID, ParameterMode.ARGUMENT,
-                "The namespace the role belongs to."));
+                "The namespace the role belongs to"));
     }
 
     @Override

--- a/modules/ejbca-ejb-cli/src/org/ejbca/ui/cli/roles/RemoveAdminCommand.java
+++ b/modules/ejbca-ejb-cli/src/org/ejbca/ui/cli/roles/RemoveAdminCommand.java
@@ -51,7 +51,7 @@ public class RemoveAdminCommand extends BaseRolesCommand {
 
     {
         registerParameter(new Parameter(ROLE_NAME_KEY, "Role Name", MandatoryMode.MANDATORY, StandaloneMode.ALLOW, ParameterMode.ARGUMENT,
-                "Role to list rules of."));
+                "Role to remove rule from"));
         registerParameter(new Parameter(CA_NAME_KEY, "CA Name", MandatoryMode.MANDATORY, StandaloneMode.ALLOW, ParameterMode.ARGUMENT,
                 "Name of the issuing CA"));
         registerParameter(new Parameter(MATCH_WITH_KEY, "Value", MandatoryMode.MANDATORY, StandaloneMode.ALLOW, ParameterMode.ARGUMENT,


### PR DESCRIPTION
## Describe your changes

Fixed one error in the help text of the `removeadmin` command and harmonized the interpunction

## How has this been tested?

n/a

## Checklist before requesting a review
<!--- To check or uncheck a box, switch between "[x]" and "[ ]" below. -->

- [x] I have performed a self-review of my code
- [x] I have kept the patch limited to only change the parts related to the patch

See also [Contributing Guidelines](../../CONTRIBUTING.md).