### PR TITLE
Allow OAuth configuration in GUI

### DIFF
--- a/modules/admin-gui/resources/administratorprivileges/rolemembers.xhtml
+++ b/modules/admin-gui/resources/administratorprivileges/rolemembers.xhtml
@@ -76,7 +76,7 @@
                         </f:facet>
                         <h:outputText value="#{roleMembersBean.getTokenIssuerIdString(roleMember)}"/>
                     </h:column>
-                    <h:column rendered="#{web.ejbcaWebBean.runningEnterprise}">
+                    <h:column rendered="true">
                         <f:facet name="header" >
                             <h:outputText value="#{web.text.OAUTHPROVIDER}"/>
                             <h:panelGroup id="oAuthProviderBlock" layout="block" rendered="#{roleMembersBean.authorizedToEditRole}">

--- a/modules/admin-gui/src/org/ejbca/ui/web/admin/administratorprivileges/RoleMembersBean.java
+++ b/modules/admin-gui/src/org/ejbca/ui/web/admin/administratorprivileges/RoleMembersBean.java
@@ -206,9 +206,10 @@ public class RoleMembersBean extends BaseManagedBean implements Serializable {
             final List<String> tokenTypes = new ArrayList<>(AccessMatchValueReverseLookupRegistry.INSTANCE.getAllTokenTypes());
             Collections.sort(tokenTypes);
             for (final String tokenType : tokenTypes) {
-                if (tokenType.equals(OAuth2AuthenticationTokenMetaData.TOKEN_TYPE) && !getEjbcaWebBean().isRunningEnterprise()) {
-                    continue;
-                }
+                // Allowing CE and Enterprise editions
+                //if (tokenType.equals(OAuth2AuthenticationTokenMetaData.TOKEN_TYPE) && !getEjbcaWebBean().isRunningEnterprise()) {
+                //    continue;
+                //}
                 final AuthenticationTokenMetaData authenticationTokenMetaData = AccessMatchValueReverseLookupRegistry.INSTANCE.getMetaData(tokenType);
                 if (authenticationTokenMetaData.isUserConfigurable()) {
                     for (final AccessMatchValue accessMatchValue : authenticationTokenMetaData.getAccessMatchValues()) {

--- a/modules/admin-gui/src/org/ejbca/ui/web/admin/configuration/SystemConfigMBean.java
+++ b/modules/admin-gui/src/org/ejbca/ui/web/admin/configuration/SystemConfigMBean.java
@@ -2137,7 +2137,7 @@ public class SystemConfigMBean extends BaseManagedBean implements Serializable {
     }
     
     public boolean renderOAuthProviders() {
-        return authorizationSession.isAuthorizedNoLogging(getAdmin(), StandardRules.ROLE_ROOT.resource()) && getEjbcaWebBean().isRunningEnterprise();
+        return authorizationSession.isAuthorizedNoLogging(getAdmin(), StandardRules.ROLE_ROOT.resource());
     }
     
     public boolean renderCustomCertificateExtensions() {


### PR DESCRIPTION
## Describe your changes

The code for OAuth authentication exists within the Community Edition, but the GUI restricts access to related pages. A few small changes allow the GUI to view and edit OAuth providers (under System Configuration), as well as to configure Role Members to be identifed using OAuth claims.

Tested using KeyCloak.
