### PR TITLE
Keep `dncomponents.properties.sample` in sync with `DnComponents#dNObjectsForward`

### DIFF
--- a/modules/ejbca-ejb/src/org/ejbca/core/ejb/ra/EndEntityManagementSessionBean.java
+++ b/modules/ejbca-ejb/src/org/ejbca/core/ejb/ra/EndEntityManagementSessionBean.java
@@ -284,7 +284,6 @@ public class EndEntityManagementSessionBean implements EndEntityManagementSessio
     public EndEntityInformation canonicalizeUser(final EndEntityInformation endEntity) throws CustomFieldException {
         // Make a deep copy
         EndEntityInformation endEntityInformationCopy = new EndEntityInformation(endEntity);
-        final int endEntityProfileId = endEntityInformationCopy.getEndEntityProfileId();
         final String dn = DnComponents.stringToBCDNString(StringTools.strip(endEntityInformationCopy.getDN()));
         endEntityInformationCopy.setDN(dn);
         endEntityInformationCopy.setSubjectAltName(StringTools.strip(endEntityInformationCopy.getSubjectAltName()));

--- a/src/java/dncomponents.properties.sample
+++ b/src/java/dncomponents.properties.sample
@@ -1,5 +1,6 @@
 #
-# Sample file specifying the order of DN components. 
+# Sample file specifying the order of DN components.
+# The sample order below is the same that EJBCA uses by default (see com.keyfactor.util.certificate.DnComponents#dNObjectsForward).
 # Can be copied to dncomponents.properties to control order of you own private DN components.
 # Normal DN order is best controlled through "Custom Subject DN Order" in Certificate Profiles.
 #
@@ -9,11 +10,10 @@
 #
 certificationid=0.4.0.127.0.7.3.10.1.2
 description=2.5.4.13
-jurisdictionLocality=1.3.6.1.4.1.311.60.2.1.1
-jurisdictionState=1.3.6.1.4.1.311.60.2.1.2
 jurisdictionCountry=1.3.6.1.4.1.311.60.2.1.3
+jurisdictionState=1.3.6.1.4.1.311.60.2.1.2
+jurisdictionLocality=1.3.6.1.4.1.311.60.2.1.1
 role=2.5.4.72
-name=2.5.4.41
 street=2.5.4.9
 pseudonym=2.5.4.65
 telephonenumber=2.5.4.20
@@ -22,10 +22,10 @@ businesscategory=2.5.4.15
 postalcode=2.5.4.17
 unstructuredaddress=1.2.840.113549.1.9.8
 unstructuredname=1.2.840.113549.1.9.2
-legalentityidentifier=1.3.6.1.4.1.53087.1.5
 wordmark=1.3.6.1.4.1.53087.1.6
 priorusemarksourceurl=1.3.6.1.4.1.53087.5.1
 trademarkidentifier=1.3.6.1.4.1.53087.1.4
+legalentityidentifier=1.3.6.1.4.1.53087.1.5
 statuteurl=1.3.6.1.4.1.53087.3.6
 statutecitation=1.3.6.1.4.1.53087.3.5
 trademarkofficename=1.3.6.1.4.1.53087.1.2
@@ -40,9 +40,10 @@ email=1.2.840.113549.1.9.1
 dn=2.5.4.46
 uniqueidentifier=2.5.4.45
 uid=0.9.2342.19200300.100.1.1
-cn=2.5.4.3
-vid=1.3.6.1.4.1.37244.2.1
 pid=1.3.6.1.4.1.37244.2.2
+vid=1.3.6.1.4.1.37244.2.1
+cn=2.5.4.3
+name=2.5.4.41
 sn=2.5.4.5
 serialnumber=2.5.4.5
 gn=2.5.4.42


### PR DESCRIPTION
## Describe your changes

The default attributes order in `com.keyfactor.util.certificate.DnComponents#dNObjectsForward` is different to the sample order provided in `src/java/dncomponents.properties.sample`.

This can lead to unexpected behavior, e.g. when a user simply copies `dncomponents.properties.sample` to `src/java/dncomponents.properties` and performs only a minor modification to the file expecting only the effect of his changes, but instead, he suddenly starts getting other attributes in a different order, which can be quite confusing, at least.

The current PR patches syncs the order in `dncomponents.properties.sample` with `DnComponents#dNObjectsForward`.

Finally, a comment should be left for developers in the (non-publicly available) source for the field `com.keyfactor.util.certificate.DnComponents#dNObjectsForward`, or even better `dncomponents.properties.sample` could possibly be automatically generated.

## Checklist before requesting a review
<!--- To check or uncheck a box, switch between "[x]" and "[ ]" below. -->

- [x] I have performed a self-review of my code
- [ ] I have kept the patch limited to only change the parts related to the patch
- [ ] This change requires a documentation update

