### PR TITLE
Cannot update EE password using AdminWeb

### DIFF
--- a/modules/admin-gui/src/org/ejbca/ui/web/admin/endentity/EditEndEntityMBean.java
+++ b/modules/admin-gui/src/org/ejbca/ui/web/admin/endentity/EditEndEntityMBean.java
@@ -1592,8 +1592,6 @@ public class EditEndEntityMBean extends EndEntityBaseManagedBean implements Seri
 
         if (regeneratePassword) {
             newUserView.setPassword("NEWPASSWORD");
-        } else {
-            newUserView.setPassword(null);
         }
 
         if (selectedPassword != null &&  (!selectedPassword.equals(""))) {


### PR DESCRIPTION
Using the AdminWeb (via RA function), updating the password for an End Entity does not work. A similar operation using the RAWeb is OK.

## Describe your changes

Identified an IF statement in EditEndEntityMBean.java that will set the password to null when regeneration is not being used. This overrides the actual password value being set by the Operator.

## How has this been tested?

Manually testing using AdminWeb.

## Checklist before requesting a review

- [X ] I have performed a self-review of my code
- [X ] I have kept the patch limited to only change the parts related to the patch
- [ ] This change requires a documentation update

See also [Contributing Guidelines](../../CONTRIBUTING.md).
