### PR TITLE
Remove ee certs after web systemtests

### DIFF
--- a/modules/systemtests/src-test/org/cesecore/CaTestUtils.java
+++ b/modules/systemtests/src-test/org/cesecore/CaTestUtils.java
@@ -231,6 +231,7 @@ public abstract class CaTestUtils {
             if (caInfo.getCAToken() != null) {
                 cryptoTokenManagementSession.deleteCryptoToken(authenticationToken, caInfo.getCAToken().getCryptoTokenId());
             }
+            internalCertificateStoreSession.removeCertificatesByIssuer(caInfo.getSubjectDN());
             internalCertificateStoreSession.removeCertificatesBySubject(caInfo.getSubjectDN());
             internalCertificateStoreSession.removeCRLs(authenticationToken, caInfo.getSubjectDN());            
         }

--- a/modules/systemtests/src-test/org/cesecore/certificates/ocsp/OcspTestUtils.java
+++ b/modules/systemtests/src-test/org/cesecore/certificates/ocsp/OcspTestUtils.java
@@ -33,6 +33,7 @@ import java.util.Map;
 
 import org.bouncycastle.asn1.ocsp.OCSPObjectIdentifiers;
 import org.bouncycastle.operator.OperatorCreationException;
+import org.cesecore.SystemTestsConfiguration;
 import org.cesecore.authentication.tokens.AuthenticationToken;
 import org.cesecore.authorization.AuthorizationDeniedException;
 import org.cesecore.certificates.ca.CADoesntExistsException;
@@ -353,7 +354,8 @@ public final class OcspTestUtils {
 
     public static void clearOcspSigningCache() {
         try {
-            final URL url = new URL("http://localhost:8080/ejbca/clearcache?command=clearcaches&excludeactivects=true");
+            final String httpPort = SystemTestsConfiguration.getRemotePortHttp("8080");
+            final URL url = new URL("http://localhost:"+httpPort+"/ejbca/clearcache?command=clearcaches&excludeactivects=true");
             final HttpURLConnection con = (HttpURLConnection) url.openConnection();
             if (con.getResponseCode() != HttpURLConnection.HTTP_OK) {
                 Assert.fail("Failed to clear caches using URL: http://localhost:8080/ejbca/clearcache?command=clearcaches&excludeactivects=true"

--- a/modules/systemtests/src-test/org/cesecore/junit/util/CryptoTokenRunner.java
+++ b/modules/systemtests/src-test/org/cesecore/junit/util/CryptoTokenRunner.java
@@ -158,6 +158,9 @@ public abstract class CryptoTokenRunner {
         } catch (AuthorizationDeniedException e) {
             throw new IllegalStateException(e);
         }
+        // Delete certs issued by the CA
+        internalCertificateStoreSession.removeCertificatesByIssuer( ca.getSubjectDN());
+
         casToRemove.remove(ca.getCAId());
     }
 

--- a/modules/systemtests/src-test/org/ejbca/core/protocol/cmp/CmpTestCase.java
+++ b/modules/systemtests/src-test/org/ejbca/core/protocol/cmp/CmpTestCase.java
@@ -149,6 +149,7 @@ import org.cesecore.certificates.certificate.CertificateCreateException;
 import org.cesecore.certificates.certificate.CertificateRevokeException;
 import org.cesecore.certificates.certificate.CertificateStoreSessionRemote;
 import org.cesecore.certificates.certificate.IllegalKeyException;
+import org.cesecore.certificates.certificate.InternalCertificateStoreSessionRemote;
 import org.cesecore.certificates.certificate.exception.CertificateSerialNumberException;
 import org.cesecore.certificates.certificate.exception.CustomCertificateSerialNumberException;
 import org.cesecore.certificates.certificate.request.ResponseStatus;
@@ -308,8 +309,14 @@ public abstract class CmpTestCase extends CaTestCase {
     }
 
     protected final void removeCAs(CA[] cas) throws AuthorizationDeniedException {
+        final InternalCertificateStoreSessionRemote internalCertificateStoreSession = EjbRemoteHelper.INSTANCE.getRemoteSession(
+                InternalCertificateStoreSessionRemote.class, EjbRemoteHelper.MODULE_TEST);
         for (CA ca : cas) {
             if (ca != null ) {
+                
+                // Delete certs issued by the CA
+                internalCertificateStoreSession.removeCertificatesByIssuer( ca.getSubjectDN());
+
                 CaTestUtils.removeCa(ADMIN, ca.getCAInfo());
             }
         }

--- a/modules/systemtests/src-test/org/ejbca/core/protocol/cmp/CrmfRARequestSystemTest.java
+++ b/modules/systemtests/src-test/org/ejbca/core/protocol/cmp/CrmfRARequestSystemTest.java
@@ -147,6 +147,9 @@ public class CrmfRARequestSystemTest extends CmpTestCase {
 
     @AfterClass
     public static void tearDownFinal() throws RoleNotFoundException, AuthorizationDeniedException {
+        // Remove issued certs
+        internalCertStoreSession.removeCertificatesByIssuer(ISSUER_DN);
+
         if (testx509ca != null) {
             CaTestUtils.removeCa(ADMIN, testx509ca.getCAInfo());
         }
@@ -799,6 +802,7 @@ public class CrmfRARequestSystemTest extends CmpTestCase {
             } finally {
                 try {
                     this.endEntityManagementSession.deleteUser(ADMIN, userName1);
+                    internalCertStoreSession.removeCertificatesByUsername(userName1);
                 } catch (NoSuchEndEntityException e) {// Do nothing
                 }
             }

--- a/modules/systemtests/src-test/org/ejbca/core/protocol/ocsp/OcspJunitHelper.java
+++ b/modules/systemtests/src-test/org/ejbca/core/protocol/ocsp/OcspJunitHelper.java
@@ -370,7 +370,7 @@ public class OcspJunitHelper {
 				*/
         final URI uriWithParam = new URI(
                 this.baseURI.getScheme(), this.baseURI.getUserInfo(), "127.0.0.1",
-                8080, this.baseURI.getPath(), param, this.baseURI.getFragment());
+                this.baseURI.getPort(), this.baseURI.getPath(), param, this.baseURI.getFragment());
 		final URL url = uriWithParam.toURL();
 		final HttpURLConnection con = (HttpURLConnection)url.openConnection();
 		log.debug("Connection to " + url.toExternalForm() + " resulted in HTTP " + con.getResponseCode());

--- a/modules/systemtests/src-test/org/ejbca/core/protocol/ocsp/ProtocolOcspHttpSystemTest.java
+++ b/modules/systemtests/src-test/org/ejbca/core/protocol/ocsp/ProtocolOcspHttpSystemTest.java
@@ -505,6 +505,7 @@ public class ProtocolOcspHttpSystemTest extends ProtocolOcspTestBase {
         } finally {
             endEntityManagementSession.deleteUser(admin, "ocsptest");
             CryptoTokenTestUtils.removeCryptoToken(admin, caInfo.getCAToken().getCryptoTokenId());
+            internalCertStoreSession.removeCertificatesByIssuer( caInfo.getSubjectDN());
         }
     } // test08OcspEcdsaGood
 


### PR DESCRIPTION
## Describe your changes

After running the "web" system tests, there are many test EE certs left behind. I've added some extra clean up code, generally at the time of the test CA removal.

I also found a few OCSP tests cases that have hard-coded references to port 8080. I've changed these to the the systemtest configuration file.

## How has this been tested?

Ran "ant test:runweb" and checked for any faliures/errors, then checked the EJBCA's CertificateData table for any new certificates left behind..

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I have kept the patch limited to only change the parts related to the patch
- [ ] This change requires a documentation update

See also [Contributing Guidelines](../../CONTRIBUTING.md).
