### PR TITLE
Added OpenSSF Badge in README.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,4 +13,4 @@
 - [ ] I have kept the patch limited to only change the parts related to the patch
 - [ ] This change requires a documentation update
 
-See also [Contributing Guidelines](../../CONTRIBUTING.md).
+See also [Contributing Guidelines](../CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 </h1>
 
 [![Discuss](https://img.shields.io/badge/discuss-ejbca-ce?style=flat)](https://github.com/Keyfactor/ejbca-ce/discussions) 
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/9419/badge)](https://www.bestpractices.dev/en/projects/9419)
 
 The open-source public key infrastructure (PKI) and certificate authority (CA) software **EJBCA** is one of the longest-running CA software projects. EJBCA is platform-independent and covers all your needs – from certificate enrollment, via certificate management, to certificate validation.
 


### PR DESCRIPTION
Added the OpenSSF Badge back to the README. 
https://www.bestpractices.dev/en/projects/9419

## Describe your changes

Added OpenSSF badge back to the README, linking to the EJBCA OpenSSF Best practices page: https://www.bestpractices.dev/en/projects/9419 
Please make sure that this badge remains in the README for the next release. 

Also fixed the link to the CONTRIBUTING Guidelines in the PR template. 

## How has this been tested?

-

## Checklist before requesting a review
<!--- To check or uncheck a box, switch between "[x]" and "[ ]" below. -->

- [x] I have performed a self-review of my code
- [x] I have kept the patch limited to only change the parts related to the patch
- [ ] This change requires a documentation update

See also [Contributing Guidelines](https://github.com/Keyfactor/ejbca-ce/blob/main/CONTRIBUTING.md).
 