### PR TITLE
Log recipients for MailSender

### DIFF
--- a/modules/ejbca-common-web/src/org/ejbca/util/mail/MailSender.java
+++ b/modules/ejbca-common-web/src/org/ejbca/util/mail/MailSender.java
@@ -181,7 +181,7 @@ public class MailSender {
 			Executors.newSingleThreadExecutor().submit(() -> {
 				try {
 					Transport.send(msg);
-					log.info("Sending email is successful.");
+					log.info("Sending email is successful. Recipients: TO: " + toList + ", CC: " + ccList);
 				} catch (MessagingException e) {
 					log.error("Unable to send email: ", e);
 				}


### PR DESCRIPTION
## Describe your changes

It is useful to log recipient for the MailSender for tracking purposes. Similar behaviour was implemented in `EndEntityManagementSessionBean` but removed in https://github.com/Keyfactor/ejbca-ce/commit/730b5400ae838f019f1d67abf93ffcbd4da42bf0.

This PR adds information about recipients into the log.

## Checklist before requesting a review
<!--- To check or uncheck a box, switch between "[x]" and "[ ]" below. -->

- [x] I have performed a self-review of my code
- [x] I have kept the patch limited to only change the parts related to the patch
- [ ] This change requires a documentation update
