### PR TITLE
Make PKIMessage.PKIHeader.senderKID optional for PBE/PBMAC1

### DIFF
--- a/modules/ejbca-common-web/src/org/ejbca/core/protocol/cmp/CmpResponseMessage.java
+++ b/modules/ejbca-common-web/src/org/ejbca/core/protocol/cmp/CmpResponseMessage.java
@@ -455,8 +455,8 @@ public class CmpResponseMessage implements CertificateResponseMessage {
                 myPKIBody = new PKIBody(23, myErrorContent); // 23 = error
             }
 
-            final boolean pbeProtected = (pbeKeyId != null) && (pbeKey != null) && (pbeDigestAlg != null) && (pbeMacAlg != null);
-            final boolean pbmac1Protected = (pbmac1KeyId != null) && (pbmac1Key != null) && (pbmac1PrfAlg != null) && (pbmac1MacAlg != null);
+            final boolean pbeProtected = (pbeKey != null) && (pbeDigestAlg != null) && (pbeMacAlg != null);
+            final boolean pbmac1Protected = (pbmac1Key != null) && (pbmac1PrfAlg != null) && (pbmac1MacAlg != null);
             if (pbeProtected) {
                 myPKIHeader.setProtectionAlg(new AlgorithmIdentifier(CMPObjectIdentifiers.passwordBasedMac));
                 PKIHeader header = myPKIHeader.build();


### PR DESCRIPTION
…since it is not used to "uniquely identify a key" as stated in RFC 4210 5.1.1. Contributed under SPDX "LGPL-2.1-or-later".

## Describe your changes

[RFC 4210 5.1.1](https://www.rfc-editor.org/rfc/rfc4210#section-5.1.1) describes the purpose of CMP's `PKIMessage.PKIHeader.senderKID`.

For PBE/PBMAC1, EJBCA CE only uses this as a courtesy in `CmpMessageHelper.protectPKIMessageWithPBMAC1(...)` to help a client distinguish between protection keys when present in the request.

```text
   These fields MUST be used if required to uniquely identify a key
   (e.g., if more than one key is associated with a given sender name)
   and SHOULD be omitted otherwise.
```

## How has this been tested?

Shared secret bootstrap use-case where CMP clients gets a cert and trust anchor in IP.

CMP config:
* RA mode
* HMAC authentication module with "Specify secret"
* Random username generation with prefix
* Response protection set to `pbe`
* Response Additional CA certificates with 1 CA cert.
* No renewal
* No server gen keys

Sending IR protected with PBMAC1 (`hmacWithSHA256` due to a [bug in BC](https://github.com/bcgit/bc-java/pull/2070).)

* Not setting `PKIMessage.PKIHeader.senderKID` results in a signed `PKIMessage` (IP).
* Setting `PKIMessage.PKIHeader.senderKID` to an empty `KeyIdentifier` (`OCTET STRING`) returns a PBMAC1 protected `PKIMessage` (IP).

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have kept the patch limited to only change the parts related to the patch
- [x] This change requires a documentation update

See also [Contributing Guidelines](../CONTRIBUTING.md).
