### PR TITLE
Make PKIMessage.PKIHeader.senderKID optional for PBE/PBMAC1 since it …

### DIFF
--- a/modules/ejbca-common-web/src/org/ejbca/core/protocol/cmp/CmpErrorResponseMessage.java
+++ b/modules/ejbca-common-web/src/org/ejbca/core/protocol/cmp/CmpErrorResponseMessage.java
@@ -123,9 +123,8 @@ public class CmpErrorResponseMessage extends BaseCmpMessage implements ResponseM
 	@Override
     public boolean create() throws InvalidKeyException, NoSuchAlgorithmException, NoSuchProviderException {
 		final PKIHeaderBuilder myPKIHeaderBuilder = CmpMessageHelper.createPKIHeaderBuilder(getSender(), getRecipient(), getSenderNonce(), getRecipientNonce(), getTransactionId());
-		final boolean pbeProtected = (getPbeDigestAlg() != null) && (getPbeMacAlg() != null) && (getPbeKeyId() != null) && (getPbeKey() != null) ;
-		final boolean pbmac1Protected = (getPbmac1PrfAlg() != null) && (getPbmac1MacAlg() != null) && (getPbmac1KeyId() != null)
-				&& (getPbmac1Key() != null);
+		final boolean pbeProtected = (getPbeDigestAlg() != null) && (getPbeMacAlg() != null) && (getPbeKey() != null) ;
+		final boolean pbmac1Protected = (getPbmac1PrfAlg() != null) && (getPbmac1MacAlg() != null) && (getPbmac1Key() != null);
 		if(pbeProtected) {
 		    myPKIHeaderBuilder.setProtectionAlg(new AlgorithmIdentifier(CMPObjectIdentifiers.passwordBasedMac));
 		}

--- a/modules/ejbca-ejb/src/org/ejbca/core/protocol/cmp/CmpConfirmResponseMessage.java
+++ b/modules/ejbca-ejb/src/org/ejbca/core/protocol/cmp/CmpConfirmResponseMessage.java
@@ -122,9 +122,8 @@ public class CmpConfirmResponseMessage extends BaseCmpMessage implements Respons
 		final PKIBody myPKIBody = new PKIBody(19, DERNull.INSTANCE);
 		PKIMessage myPKIMessage = null;
 
-		final boolean pbeProtected = (getPbeDigestAlg() != null) && (getPbeMacAlg() != null) && (getPbeKeyId() != null) && (getPbeKey() != null) ;
-		final boolean pbmac1Protected = (getPbmac1PrfAlg() != null) && (getPbmac1MacAlg() != null) && (getPbmac1KeyId() != null)
-				&& (getPbmac1Key() != null);
+		final boolean pbeProtected = (getPbeDigestAlg() != null) && (getPbeMacAlg() != null) && (getPbeKey() != null);
+		final boolean pbmac1Protected = (getPbmac1PrfAlg() != null) && (getPbmac1MacAlg() != null) && (getPbmac1Key() != null);
 		if (pbeProtected) {
 		    myPKIHeader.setProtectionAlg(new AlgorithmIdentifier(new ASN1ObjectIdentifier(getPbeDigestAlg())));
 		    myPKIMessage = new PKIMessage(myPKIHeader.build(), myPKIBody);


### PR DESCRIPTION
…is not used to "uniquely identify a key" as stated in RFC 4210 5.1.1. Contributed under SPDX "LGPL-2.1-or-later".

## Describe your changes

Followup to #871 as requested.

## How has this been tested?

Completely untested, since this was not required for my current integration. :)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have kept the patch limited to only change the parts related to the patch
- [ ] This change requires a documentation update

See also [Contributing Guidelines](../CONTRIBUTING.md).
