### PR TITLE
Remove double resources definiton

### DIFF
--- a/charts/ejbca/templates/deployment.yaml
+++ b/charts/ejbca/templates/deployment.yaml
@@ -182,8 +182,6 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: {{ include "ejbca.imageRepository" . }}:{{ .Values.image.tag | default .Chart.AppVersion }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          resources:
-            {{- toYaml .Values.resources | nindent 12 }}
           env: {{- include "ejbca.ejbcaDeploymentParameters" . | nindent 12 }}
             {{- if or (.Values.services.proxyAJP.enabled) (.Values.httpd.enabled) }}
             - name: PROXY_AJP_BIND


### PR DESCRIPTION
## Describe your changes

In the deployment template, the resources section got rendered twice.
The resulting manifest cannot be used with argocd.
I kept the one that came with the initial commit and deleted the additional.

## How has this been tested?
Argocd deployment is working

## Checklist before requesting a review
<!--- To check or uncheck a box, switch between "[x]" and "[ ]" below. -->

- [x] I have performed a self-review of my code
- [x] I have kept the patch limited to only change the parts related to the patch
- [ ] This change requires a documentation update
